### PR TITLE
feat: add static-site file kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ on Cloudflare."**
 Features at a glance:
 
 - Multi-file dashboard with **folders** (nested, per-user) and **tags**
-- Three equal-priority file types today (Excalidraw, draw.io, Notes via
-  [BlockNote](https://www.blocknotejs.org/)), more later
+- Four equal-priority file kinds today (Excalidraw, draw.io, Notes via
+  [BlockNote](https://www.blocknotejs.org/), and **Static sites** for
+  publishing uploaded HTML/CSS/JS bundles), more later
 - **Share links** for individual files or whole folder subtrees, read or
   read-write, with optional expiry and downloads
 - **Email + password auth**, invitation-only signup, super-admin bootstrap
@@ -53,6 +54,13 @@ Key choices:
 - **R2 holds the bytes, D1 holds the index.** Listing the dashboard never
   hits R2 — D1 returns metadata in milliseconds. R2 is only touched on open
   and save.
+- **Static-site files** are multi-asset bundles: the canonical JSON blob
+  is a *manifest* listing every uploaded file, and each asset lives at
+  `static-sites/{id}/{relpath}` in R2. The Worker serves them through a
+  signed `/sites/...` (owner) and `/shared/...` (share-token) routes so uploaded JS
+  cannot read session cookies or call `/api/*` as the owner. See
+  [`worker/services/static-site.ts`](./worker/services/static-site.ts)
+  and [`worker/routes/render.ts`](./worker/routes/render.ts).
 - **Optimistic concurrency** via an integer `version` column and `If-Match`.
 - **Client-side SVG thumbnails** (`exportToSvg` on a debounce). No
   server-side rendering required.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
+    "fflate": "^0.8.2",
     "hono": "^4.12.16",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260503.1)
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       hono:
         specifier: ^4.12.16
         version: 4.12.16
@@ -3308,6 +3311,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -8027,6 +8033,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -12,6 +12,7 @@ import { LoginPage } from "@/features/auth/LoginPage";
 import { EditorPage } from "@/features/editor/EditorPage";
 import { SharedEditorPage } from "@/features/editor/SharedEditorPage";
 import { SharedTokenLandingPage } from "@/features/editor/SharedTokenLandingPage";
+import { StaticSitePreviewRedirect } from "@/features/editor/StaticSitePreviewRedirect";
 import { DashboardPage } from "@/features/explorer/DashboardPage";
 import { SettingsPage } from "@/features/settings/SettingsPage";
 import { SharesPage } from "@/features/sharing/SharesPage";
@@ -24,6 +25,11 @@ export function AppRoutes() {
       <Route path="/" element={<DashboardPage />} />
       <Route path="/folders/:folderId" element={<DashboardPage />} />
       <Route path="/f/:id" element={<EditorPage />} />
+      {/* Owner-facing stable preview URL for static-site files. The
+          component mints a fresh signed `/sites/:id/:sig/...` URL on
+          every visit and `location.replace`s into it — see
+          StaticSitePreviewRedirect for the access-control story. */}
+      <Route path="/f/:id/site" element={<StaticSitePreviewRedirect />} />
       {/* Legacy: pre-rebrand `/s/:id` URLs (bookmarks, browser history,
           tabs) redirect to the canonical /f/:id form. */}
       <Route path="/s/:id" element={<LegacyFileRedirect />} />

--- a/src/components/sketch/brand-logos.tsx
+++ b/src/components/sketch/brand-logos.tsx
@@ -252,3 +252,90 @@ export function NotesLogo({
     </svg>
   );
 }
+
+// ───────────────────────────────────────────────────────────────
+// Static-site logo.
+//
+// No third-party brand to honor here — this is an Inkwell-native
+// "site" mark: a browser-window glyph (top bar + traffic-light dots
+// + content area). Two variants follow the same "full" / "mark"
+// contract as the other kinds.
+//
+// Color: a deep indigo close to Tailwind `indigo-600`, picked so the
+// chip reads as a distinct fourth brand next to the existing purple
+// (Excalidraw) and cyan→purple (BlockNote) marks.
+const STATIC_SITE_BG = "#EEF2FF"; // indigo-50
+const STATIC_SITE_INK = "#4338CA"; // indigo-700
+const STATIC_SITE_DOT = "#94A3B8"; // slate-400
+
+/** Static-site brand mark (used for `kind === "static-site"` files). */
+export function StaticSiteLogo({
+  variant = "mark",
+  className,
+}: {
+  variant?: BrandLogoVariant;
+  className?: string;
+}) {
+  if (variant === "full") {
+    return (
+      <svg
+        viewBox="0 0 500 500"
+        xmlns="http://www.w3.org/2000/svg"
+        className={cn("size-full", className)}
+        aria-hidden
+      >
+        <title>Static site</title>
+        {/* Soft indigo background chip with rounded corners. */}
+        <rect x="0" y="0" width="500" height="500" rx="110" fill={STATIC_SITE_BG} />
+        {/* Browser-window frame. */}
+        <rect
+          x="80"
+          y="110"
+          width="340"
+          height="280"
+          rx="32"
+          fill="white"
+          stroke={STATIC_SITE_INK}
+          strokeWidth="14"
+        />
+        {/* Title bar divider. */}
+        <line x1="80" y1="175" x2="420" y2="175" stroke={STATIC_SITE_INK} strokeWidth="14" />
+        {/* Traffic-light dots. */}
+        <circle cx="118" cy="143" r="10" fill={STATIC_SITE_DOT} />
+        <circle cx="152" cy="143" r="10" fill={STATIC_SITE_DOT} />
+        <circle cx="186" cy="143" r="10" fill={STATIC_SITE_DOT} />
+        {/* Content lines. */}
+        <rect x="120" y="220" width="180" height="22" rx="6" fill={STATIC_SITE_INK} />
+        <rect x="120" y="260" width="260" height="14" rx="5" fill={STATIC_SITE_DOT} />
+        <rect x="120" y="290" width="240" height="14" rx="5" fill={STATIC_SITE_DOT} />
+        <rect x="120" y="320" width="200" height="14" rx="5" fill={STATIC_SITE_DOT} />
+      </svg>
+    );
+  }
+  // Inline "mark" variant: simplified browser-window glyph, indigo
+  // strokes on transparent, sized like the other marks.
+  return (
+    <svg
+      viewBox="0 0 500 500"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("size-3.5", className)}
+      aria-hidden
+    >
+      <title>Static site</title>
+      <rect
+        x="60"
+        y="90"
+        width="380"
+        height="320"
+        rx="40"
+        fill="none"
+        stroke={STATIC_SITE_INK}
+        strokeWidth="28"
+      />
+      <line x1="60" y1="170" x2="440" y2="170" stroke={STATIC_SITE_INK} strokeWidth="28" />
+      <circle cx="108" cy="130" r="14" fill={STATIC_SITE_INK} />
+      <circle cx="152" cy="130" r="14" fill={STATIC_SITE_INK} />
+      <circle cx="196" cy="130" r="14" fill={STATIC_SITE_INK} />
+    </svg>
+  );
+}

--- a/src/components/sketch/file-kind-icons.tsx
+++ b/src/components/sketch/file-kind-icons.tsx
@@ -15,7 +15,13 @@
 
 import type { FileKind } from "@/lib/api/client";
 import { cn } from "@/lib/utils";
-import { type BrandLogoVariant, DrawioLogo, ExcalidrawLogo, NotesLogo } from "./brand-logos";
+import {
+  type BrandLogoVariant,
+  DrawioLogo,
+  ExcalidrawLogo,
+  NotesLogo,
+  StaticSiteLogo,
+} from "./brand-logos";
 
 export type FileKindGlyphVariant = BrandLogoVariant;
 
@@ -35,6 +41,7 @@ export function FileKindGlyph({
 }) {
   if (kind === "drawio") return <DrawioLogo variant={variant} className={className} />;
   if (kind === "notes") return <NotesLogo variant={variant} className={className} />;
+  if (kind === "static-site") return <StaticSiteLogo variant={variant} className={className} />;
   return <ExcalidrawLogo variant={variant} className={className} />;
 }
 
@@ -44,6 +51,8 @@ export function fileKindLabel(kind: FileKind): string {
       return "draw.io file";
     case "notes":
       return "notes file";
+    case "static-site":
+      return "static site";
     default:
       return "excalidraw file";
   }
@@ -62,6 +71,8 @@ export function downloadLabelForKind(kind: FileKind): string {
       return "Download .drawio";
     case "notes":
       return "Download .notes.json";
+    case "static-site":
+      return "Download .zip";
     default:
       return "Download .excalidraw";
   }

--- a/src/features/editor/EditorPage.tsx
+++ b/src/features/editor/EditorPage.tsx
@@ -32,6 +32,7 @@ import { EditorErrorState, EditorLoadingState } from "./EditorChrome";
 import ExcalidrawEditor from "./ExcalidrawEditor";
 import NotesEditor from "./NotesEditor";
 import { RenameFileDialog } from "./RenameFileDialog";
+import StaticSiteEditor from "./StaticSiteEditor";
 
 export function EditorPage() {
   const { id = "" } = useParams<{ id: string }>();
@@ -199,6 +200,7 @@ export function EditorPage() {
         targetType="file"
         targetId={id}
         targetName={loaded.meta.name}
+        targetKind={loaded.meta.kind}
       />
 
       {tagsOpen && fileTags.status === "ok" && tagsQuery.data ? (
@@ -249,6 +251,41 @@ export function EditorPage() {
             onDownload: () => {
               window.location.href = files.downloadUrl(id);
             },
+          }}
+        />
+        {fileDialogs}
+      </div>
+    );
+  }
+
+  if (loaded.meta.kind === "static-site") {
+    // StaticSiteEditor paints its own <PaperSurface> and owns its own
+    // scroll container — the wrapper just sizes to the viewport.
+    return (
+      <div className="h-dvh w-full">
+        <StaticSiteEditor
+          loaded={loaded}
+          back={{ onClick: handleBack, label: "Back to dashboard" }}
+          onRequestRename={() => setRenameOpen(true)}
+          onTags={() => setTagsOpen(true)}
+          onShare={() => setShareOpen(true)}
+          onManifestChanged={(_manifest, meta) => {
+            // Keep the editor's `LoadedFile` mirror in sync with the
+            // server's bumped version so subsequent mutations send the
+            // right `If-Match` header.
+            setLoaded((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    meta: {
+                      ...prev.meta,
+                      version: meta.version,
+                      updatedAt: meta.updatedAt,
+                      name: meta.name,
+                    },
+                  }
+                : prev,
+            );
           }}
         />
         {fileDialogs}

--- a/src/features/editor/SharedEditorPage.tsx
+++ b/src/features/editor/SharedEditorPage.tsx
@@ -34,6 +34,7 @@ import { keys } from "@/lib/api/query-keys";
 import { errorMessage } from "@/lib/errors";
 import { useTheme } from "@/lib/theme";
 import { EditorErrorState, EditorLoadingState } from "./EditorChrome";
+import { SharedStaticSitePreviewRedirect } from "./StaticSitePreviewRedirect";
 
 interface SharedEditorProps {
   /** Optional preloaded file; used by SharedTokenLanding to avoid a double fetch. */
@@ -116,6 +117,20 @@ export function SharedEditorPage({ preloaded }: SharedEditorProps = {}) {
   const downloadHref = fileId
     ? shares.folderFileDownloadUrl(token, fileId)
     : shares.downloadUrl(token);
+
+  if (loaded.meta.kind === "static-site") {
+    // Share-token visitors don't see the management surface for
+    // static-site bundles — the file tree is an owner concept. We
+    // bounce to the signed preview URL exactly the way the top-level
+    // `/share/:token` dispatcher does for file shares, but minting
+    // through the folder-share render endpoint when this is a
+    // folder-share child (fileId present). The share render-session
+    // endpoint re-checks `findActive`, so revoking the share kills
+    // the outstanding session immediately.
+    return (
+      <SharedStaticSitePreviewRedirect token={token} fileId={fileId ?? null} blob={loaded.blob} />
+    );
+  }
 
   if (loaded.meta.kind === "drawio") {
     return (

--- a/src/features/editor/SharedTokenLandingPage.tsx
+++ b/src/features/editor/SharedTokenLandingPage.tsx
@@ -3,6 +3,21 @@
 // The same URL serves both file shares and folder shares; we peek the
 // token once and pick the right view. The peek result is fed to the
 // child as `preloaded` so neither child re-fetches.
+//
+// Special case for static-site file shares: rather than rendering the
+// `StaticSiteEditor` management surface (which would show share
+// visitors a read-only file list of the bundle), we mint a share
+// render-session and redirect to the signed `/shared/:token/:sig/...`
+// URL. For static-site content the *preview* is the thing visitors
+// are meant to see; the file-list surface is an owner concept.
+//
+// We deliberately do NOT do the same redirect for folder shares (a
+// folder share never resolves to a single previewable artifact) or
+// for non-static-site file shares (those need the in-app editor for
+// view/edit semantics). The analogous redirect for folder-share
+// CHILDREN that happen to be static-site files lives in
+// `SharedEditorPage` — it can't run here because the dispatcher
+// doesn't see the child fileId.
 
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
@@ -14,6 +29,7 @@ import { errorMessage } from "@/lib/errors";
 
 import { SharedEditorPage } from "./SharedEditorPage";
 import SharedFolderPage from "./SharedFolderPage";
+import { SharedStaticSitePreviewRedirect } from "./StaticSitePreviewRedirect";
 
 export function SharedTokenLandingPage() {
   const { token = "" } = useParams<{ token: string }>();
@@ -47,6 +63,11 @@ export function SharedTokenLandingPage() {
   if (!data) return null;
   if (data.type === "folder") {
     return <SharedFolderPage preloaded={data.payload} />;
+  }
+  // Static-site file shares → redirect to the signed preview URL
+  // rather than rendering the read-only management surface.
+  if (data.file.meta.kind === "static-site") {
+    return <SharedStaticSitePreviewRedirect token={token} fileId={null} blob={data.file.blob} />;
   }
   return <SharedEditorPage preloaded={data.file} />;
 }

--- a/src/features/editor/StaticSiteEditor.tsx
+++ b/src/features/editor/StaticSiteEditor.tsx
@@ -1,0 +1,363 @@
+// StaticSiteEditor — management surface for `kind === "static-site"`.
+//
+// This is **not** an editor in the traditional sense — there is no
+// canvas, no autosave, no in-place editing. A static-site file is a
+// bundle of HTML/CSS/JS/image assets authored elsewhere (typically by
+// the richdoc CLI). The job of this page is:
+//
+//   1. Show what's in the bundle (file list, entry page, sizes).
+//   2. Let the owner modify the bundle (upload, replace via ZIP,
+//      delete, change entry).
+//   3. Expose the rendered site as a one-click new-tab open at
+//      `/sites/:id/:sig/<entry>` (signed). Share-token visitors
+//      never see this management surface — they are redirected
+//      straight to the signed `/shared/:token/:sig/<entry>` (or
+//      `/shared/:token/files/:fileId/:sig/<entry>` for folder
+//      shares) by `SharedTokenLandingPage` / `SharedEditorPage`.
+//
+// There is intentionally no inline iframe preview on this page —
+// the rendered site lives at its own URL (`/sites/...` for the
+// owner, `/shared/...` for share-token visitors), and the "Open"
+// button on the site card (or topbar) is the only way in. That
+// keeps this page focused on bundle management and avoids paying
+// for a render-session every time the user navigates here.
+//
+// Security: see `StaticSitePreviewRedirect.tsx` for the signed-URL
+// contract. The `mintSession` mutation here is the same mint used
+// there, called lazily from the "Open" click handler so we don't
+// pay for a session until the user actually wants one.
+//
+// Concurrency: every mutator (upload, delete, set-entry, ZIP-upload)
+// is its own POST. We pass `If-Match: <version>` and surface 409s as
+// a toast + manifest refetch. No autosave loop, no `useSaveLifecycle`
+// scaffolding — those exist for content that's edited in-place.
+//
+// Layout: a `<PaperSurface>` page with a single editor-owned topbar
+// and a two-column grid on `lg:` (SiteCard + UploadPanel side by
+// side, FilesList full-width below). On `<lg` the columns stack.
+// Subcomponents live in `./static-site/`.
+
+import {
+  ArrowLeft01Icon,
+  Download01Icon,
+  Edit02Icon,
+  HashtagIcon,
+  LinkSquare01Icon,
+  Share08Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { PaperSurface } from "@/components/PaperSurface";
+import { FileKindGlyph } from "@/components/sketch/file-kind-icons";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  type FileMeta,
+  files,
+  type LoadedFile,
+  type StaticSiteFileBlob,
+  type StaticSiteRenderSession,
+  staticSites,
+} from "@/lib/api/client";
+import { keys } from "@/lib/api/query-keys";
+import { errorMessage } from "@/lib/errors";
+import { cn } from "@/lib/utils";
+import { FilesList } from "./static-site/FilesList";
+import { SiteCard } from "./static-site/SiteCard";
+import { UploadPanel } from "./static-site/UploadPanel";
+
+export interface StaticSiteEditorProps {
+  loaded: LoadedFile;
+  /** Optional back affordance (hidden when `null`). */
+  back?: { onClick: () => void; label: string } | null;
+  onRequestRename?: () => void;
+  onTags?: () => void;
+  onShare?: () => void;
+  /** Override the download URL — defaults to the owner endpoint. */
+  downloadUrl?: string;
+  /** Override the render-session minter — defaults to owner's.
+   *  Share-token viewers pass `() => shares.renderSession(token)`. */
+  mintSession?: () => Promise<StaticSiteRenderSession>;
+  /** When false, hides every mutation control (uploads, delete, entry).
+   *  Used by the read-only share-token view. */
+  writable?: boolean;
+  /** Optional callback fired after a successful mutation so the
+   *  parent can patch its own LoadedFile. */
+  onManifestChanged?: (manifest: StaticSiteFileBlob, meta: FileMeta) => void;
+}
+
+export default function StaticSiteEditor({
+  loaded,
+  back,
+  onRequestRename,
+  onTags,
+  onShare,
+  downloadUrl,
+  mintSession,
+  writable = true,
+  onManifestChanged,
+}: StaticSiteEditorProps) {
+  const id = loaded.meta.id;
+  const qc = useQueryClient();
+
+  // Manifest: seed from `loaded.blob` so the first paint is instant,
+  // then keep in sync via `useQuery`. Subsequent mutations write
+  // directly into the cache via `setQueryData`.
+  const initialManifest = useMemo(() => coerceManifest(loaded.blob), [loaded.blob]);
+  const manifestQuery = useQuery({
+    queryKey: keys.files.manifest(id),
+    queryFn: () => staticSites.manifest(id),
+    initialData: initialManifest,
+    staleTime: 30_000,
+  });
+  const manifest = manifestQuery.data ?? initialManifest;
+  const isEmpty = manifest.assets.length === 0;
+
+  // Local version mirror — bumped on every successful mutation. The
+  // server's `If-Match` precondition keeps two concurrent tabs honest.
+  const [version, setVersion] = useState(loaded.meta.version);
+  useEffect(() => {
+    setVersion(loaded.meta.version);
+  }, [loaded.meta.version]);
+
+  // ── Mutation helpers ─────────────────────────────────────────────
+  type MutResult = Awaited<ReturnType<typeof staticSites.uploadAssets>>;
+  const onMutated = useCallback(
+    (result: MutResult) => {
+      setVersion(result.meta.version);
+      qc.setQueryData(keys.files.manifest(id), result.manifest);
+      qc.invalidateQueries({ queryKey: ["files", "list"] });
+      qc.invalidateQueries({ queryKey: ["folders", "list"] });
+      onManifestChanged?.(result.manifest, result.meta);
+    },
+    [id, onManifestChanged, qc],
+  );
+
+  const uploadFilesMutation = useMutation({
+    mutationFn: (entries: Array<File | { path: string; file: File }>) =>
+      staticSites.uploadAssets(id, entries, version),
+    onSuccess: onMutated,
+    onError: (e) => toast.error(errorMessage(e, "upload failed")),
+  });
+  const uploadZipMutation = useMutation({
+    mutationFn: (zip: Blob) => staticSites.uploadZip(id, zip, version),
+    onSuccess: onMutated,
+    onError: (e) => toast.error(errorMessage(e, "upload failed")),
+  });
+  const deleteAssetMutation = useMutation({
+    mutationFn: (path: string) => staticSites.deleteAsset(id, path, version),
+    onSuccess: onMutated,
+    onError: (e) => toast.error(errorMessage(e, "delete failed")),
+  });
+  const setEntryMutation = useMutation({
+    mutationFn: (path: string) => staticSites.setEntry(id, path, version),
+    onSuccess: onMutated,
+    onError: (e) => toast.error(errorMessage(e, "set entry failed")),
+  });
+
+  // ── Open preview (lazy mint) ─────────────────────────────────────
+  // We deliberately do NOT useQuery a render session on mount — this
+  // page has no iframe, so a session is only needed when the user
+  // actually clicks "Open". To avoid popup blockers (which fire when
+  // `window.open` is called *after* an async hop), we open a blank
+  // window synchronously inside the click handler and set its
+  // `location.href` once the mint resolves.
+  const openPreviewMutation = useMutation({
+    mutationFn: mintSession ?? (() => staticSites.renderSession(id)),
+  });
+
+  const onOpenPreview = useCallback(() => {
+    if (isEmpty) return;
+    // NB: deliberately *no* `noopener` in the features string. With
+    // `noopener` the browser specifies `window.open` returns null, so
+    // we'd lose the handle we need to redirect the new tab once the
+    // render session mints. We sever `win.opener` manually below
+    // (after the redirect) to get the same isolation — the new tab
+    // also loads with a null-origin sandbox CSP, so even without the
+    // sever it couldn't read this window's DOM.
+    const win = window.open("about:blank", "_blank");
+    if (!win) {
+      toast.error("Could not open a new tab (popup blocked?)");
+      return;
+    }
+    openPreviewMutation.mutate(undefined, {
+      onSuccess: (session) => {
+        win.location.href = session.prefix + encodePath(manifest.entry);
+        // Sever the link to this window once the navigation is in
+        // flight. Some browsers null this out automatically on
+        // cross-document navigation; doing it explicitly is harmless
+        // and removes a footgun if a future signed URL ever resolves
+        // to same-origin SPA content.
+        try {
+          win.opener = null;
+        } catch {
+          // Cross-origin reads on `win.opener` can throw after the
+          // navigation begins — nothing to do here.
+        }
+      },
+      onError: (e) => {
+        win.close();
+        toast.error(errorMessage(e, "preview unavailable"));
+      },
+    });
+  }, [isEmpty, manifest.entry, openPreviewMutation]);
+
+  const totalBytes = useMemo(() => totalSize(manifest), [manifest]);
+  const totalLabel = `${manifest.assets.length} · ${formatBytes(totalBytes)}`;
+
+  // ── Render ────────────────────────────────────────────────────────
+  return (
+    <PaperSurface variant="page" className="flex h-dvh flex-col">
+      {/* Editor topbar — borderless, glass-blur over the paper. Open
+          is the brand CTA; everything else is ghost. */}
+      <header className="sticky top-0 z-30 flex h-14 shrink-0 items-center gap-2 bg-background/85 px-3 backdrop-blur sm:px-5 supports-backdrop-filter:bg-background/70">
+        {back ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={back.onClick}
+            aria-label={back.label}
+            title={back.label}
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} />
+          </Button>
+        ) : null}
+        <FileKindGlyph kind="static-site" variant="full" className="size-6 rounded" />
+        <div className="min-w-0 flex-1 truncate font-heading text-sm font-semibold">
+          {loaded.meta.name}
+        </div>
+        <div className="hidden items-center gap-1 sm:flex">
+          {onRequestRename ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onRequestRename}
+              title="Rename"
+              aria-label="Rename"
+            >
+              <HugeiconsIcon icon={Edit02Icon} />
+              <span className="hidden md:inline">Rename</span>
+            </Button>
+          ) : null}
+          {onTags ? (
+            <Button variant="ghost" size="sm" onClick={onTags} title="Tags" aria-label="Tags">
+              <HugeiconsIcon icon={HashtagIcon} />
+              <span className="hidden md:inline">Tags</span>
+            </Button>
+          ) : null}
+          {onShare ? (
+            <Button variant="ghost" size="sm" onClick={onShare} title="Share" aria-label="Share">
+              <HugeiconsIcon icon={Share08Icon} />
+              <span className="hidden md:inline">Share</span>
+            </Button>
+          ) : null}
+        </div>
+        <Separator orientation="vertical" className="mx-1 h-6" />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            window.location.href = downloadUrl ?? files.downloadUrl(id);
+          }}
+          title="Download as .zip"
+          aria-label="Download"
+        >
+          <HugeiconsIcon icon={Download01Icon} />
+          <span className="hidden md:inline">.zip</span>
+        </Button>
+        <Button
+          variant="default"
+          size="default"
+          onClick={onOpenPreview}
+          disabled={isEmpty || openPreviewMutation.isPending}
+          title={isEmpty ? "Upload files to enable preview" : "Open rendered site in a new tab"}
+          aria-label="Open in new tab"
+        >
+          <HugeiconsIcon icon={LinkSquare01Icon} />
+          <span className="hidden sm:inline">Open</span>
+        </Button>
+      </header>
+
+      {/* Main content: SiteCard + UploadPanel (or just SiteCard in
+          read-only mode), then FilesList full-width below. */}
+      <main className="min-h-0 flex-1 overflow-y-auto">
+        <div
+          className={cn("mx-auto grid w-full max-w-6xl gap-5 px-4 py-6 sm:px-6", "lg:grid-cols-12")}
+        >
+          <div className={cn("lg:col-span-7", !writable && "lg:col-span-12")}>
+            <SiteCard
+              id={id}
+              entry={manifest.entry}
+              isEmpty={isEmpty}
+              fileCount={manifest.assets.length}
+              totalLabel={formatBytes(totalBytes)}
+              onOpen={onOpenPreview}
+              openPending={openPreviewMutation.isPending}
+            />
+          </div>
+
+          {writable ? (
+            <div className="lg:col-span-5">
+              <UploadPanel
+                id={id}
+                isEmpty={isEmpty}
+                filesPending={uploadFilesMutation.isPending}
+                zipPending={uploadZipMutation.isPending}
+                onUploadFiles={(entries) => uploadFilesMutation.mutate(entries)}
+                onUploadZip={(zip) => uploadZipMutation.mutate(zip)}
+              />
+            </div>
+          ) : null}
+
+          <div className="lg:col-span-12">
+            <FilesList
+              id={id}
+              manifest={manifest}
+              totalLabel={totalLabel}
+              writable={writable}
+              busy={setEntryMutation.isPending || deleteAssetMutation.isPending}
+              onSetEntry={(path) => setEntryMutation.mutate(path)}
+              onDelete={(path) => deleteAssetMutation.mutate(path)}
+            />
+          </div>
+        </div>
+      </main>
+    </PaperSurface>
+  );
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+/** Coerce whatever `loaded.blob` was into a manifest. New static-site
+ *  files always carry a real `StaticSiteFileBlob`; degenerate cases
+ *  (manual API calls, future migrations) fall back to an empty
+ *  manifest so the UI doesn't crash on load. */
+function coerceManifest(blob: unknown): StaticSiteFileBlob {
+  if (blob && typeof blob === "object") {
+    const o = blob as { kind?: unknown; entry?: unknown; assets?: unknown };
+    if (o.kind === "static-site" && typeof o.entry === "string" && Array.isArray(o.assets)) {
+      return blob as StaticSiteFileBlob;
+    }
+  }
+  return { kind: "static-site", entry: "index.html", assets: [] };
+}
+
+function totalSize(m: StaticSiteFileBlob): number {
+  return m.assets.reduce((a, b) => a + b.size, 0);
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+/** Percent-encode each path segment without touching the slashes. The
+ *  signed URL prefix already contains the asset id + sig; relpath
+ *  must be safe to splice in. */
+function encodePath(p: string): string {
+  return p.split("/").map(encodeURIComponent).join("/");
+}

--- a/src/features/editor/StaticSitePreviewRedirect.tsx
+++ b/src/features/editor/StaticSitePreviewRedirect.tsx
@@ -1,0 +1,148 @@
+// Preview-redirect components for static-site files.
+//
+// Two flavors, one per access path:
+//
+//   * `StaticSitePreviewRedirect`         (owner, `/f/:id/site`)
+//   * `SharedStaticSitePreviewRedirect`   (visitor, `/share/:token`
+//                                          or `/share/:token/files/:fileId`)
+//
+// Both mint a short-lived signed URL prefix and `window.location.replace`
+// to `prefix + manifest.entry`. We use `replace` (not assign) so the
+// browser back button skips this bouncing entry.
+//
+// Why a stable URL rather than just an "Open in new tab" button in
+// the management editor: signed `/sites/...` and `/shared/.../sig/...`
+// URLs expire after 30 minutes, so they can't be bookmarked or pasted
+// into chat. These routes are the bookmarkable canonical preview
+// entry points — they mint a fresh session every visit.
+//
+// Access control:
+//   * Owner path goes through `staticSites.renderSession(id)` and
+//     `staticSites.manifest(id)`. Both 404 unless the caller owns the
+//     file. Anonymous / wrong-user visitors land on the same error
+//     state as a missing file. The signed `/sites/...` URL the
+//     redirect targets ALSO requires session + ownership at the
+//     worker layer (see `worker/routes/render.ts`); the sig is a
+//     TTL-bound defense in depth.
+//   * Share path goes through `shares.renderSession(token)` (file
+//     share) or `shares.renderSessionForFile(token, fileId)` (folder
+//     share). The share render-session endpoint re-checks the share
+//     row, so revoked/expired shares produce a 403 here and surface
+//     as an error state below.
+
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ApiError, type StaticSiteFileBlob, shares, staticSites } from "@/lib/api/client";
+import { errorMessage } from "@/lib/errors";
+import { EditorErrorState, EditorLoadingState } from "./EditorChrome";
+
+// ─── Owner ────────────────────────────────────────────────────────
+
+export function StaticSitePreviewRedirect() {
+  const { id = "" } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        // Fetch manifest + signature in parallel — both are required
+        // before we can build the redirect target.
+        const [session, manifest] = await Promise.all([
+          staticSites.renderSession(id),
+          staticSites.manifest(id),
+        ]);
+        if (cancelled) return;
+        window.location.replace(session.prefix + encodePath(manifest.entry));
+      } catch (e) {
+        if (cancelled) return;
+        // 400 on render-session means the file exists but isn't a
+        // static-site. Bounce to the canonical editor URL so users
+        // pasting `/f/:id/site` for a non-static-site file still
+        // land somewhere sensible.
+        if (e instanceof ApiError && e.status === 400) {
+          navigate(`/f/${id}`, { replace: true });
+          return;
+        }
+        setError(errorMessage(e, "could not open preview"));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id, navigate]);
+
+  if (error) return <EditorErrorState message={error} />;
+  return <EditorLoadingState label="Opening preview…" />;
+}
+
+// ─── Visitor (share) ──────────────────────────────────────────────
+
+/** Redirect a share-token visitor to the signed render URL for a
+ *  static-site bundle.
+ *
+ *  - When `fileId` is null, this is a top-level file share; we mint
+ *    via `shares.renderSession(token)`.
+ *  - When `fileId` is provided, this is a folder-share child; we
+ *    mint via `shares.renderSessionForFile(token, fileId)`. The URL
+ *    shape on the worker side differs (`/shared/:token/files/:fileId/:sig/…`)
+ *    but that's encapsulated in the returned `prefix`.
+ *
+ *  `blob` is the peeked manifest — passed in rather than re-fetched
+ *  because callers always have it on hand.
+ */
+export function SharedStaticSitePreviewRedirect({
+  token,
+  fileId,
+  blob,
+}: {
+  token: string;
+  fileId: string | null;
+  blob: unknown;
+}) {
+  const [error, setError] = useState<string | null>(null);
+
+  // Pull entry out of the peeked manifest. Defensive cast: callers
+  // are expected to have already narrowed `meta.kind === "static-site"`,
+  // but blob is typed as the FileBlob union upstream.
+  const entry =
+    blob && typeof blob === "object" && (blob as StaticSiteFileBlob).kind === "static-site"
+      ? (blob as StaticSiteFileBlob).entry
+      : null;
+
+  useEffect(() => {
+    if (!token || !entry) {
+      if (!entry) setError("This share is missing a preview entry page.");
+      return;
+    }
+    let cancelled = false;
+    const mint = fileId ? shares.renderSessionForFile(token, fileId) : shares.renderSession(token);
+    mint
+      .then((session) => {
+        if (cancelled) return;
+        window.location.replace(session.prefix + encodePath(entry));
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(errorMessage(e, "could not open preview"));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, fileId, entry]);
+
+  if (error) return <EditorErrorState message={error} />;
+  return <EditorLoadingState label="Opening preview…" />;
+}
+
+// ─── Shared helper ────────────────────────────────────────────────
+
+/** Percent-encode each path segment without touching the slashes. The
+ *  signed URL prefix already contains the file id + sig (or the
+ *  folder-share variant); the relpath must be safe to splice in.
+ *  Mirrors the helper in StaticSiteEditor. */
+function encodePath(p: string): string {
+  return p.split("/").map(encodeURIComponent).join("/");
+}

--- a/src/features/editor/static-site/FileRow.tsx
+++ b/src/features/editor/static-site/FileRow.tsx
@@ -1,0 +1,174 @@
+// FileRow — one paper-sheet-style row inside the static-site file
+// list. Renders:
+//
+//   [KindChip]  path                                size   [Entry ribbon | actions]
+//
+// Visual notes:
+//   - The entry row gets a 1px primary stripe down its left edge (a
+//     subtle "this is the page that publishes" marker) and a
+//     handwritten "entry" washi ribbon on the right.
+//   - Non-entry rows reveal a two-icon cluster (set-as-entry + delete)
+//     on hover / focus-within, identical in behaviour to the previous
+//     implementation. The reservation column is always present so the
+//     row layout doesn't shift when actions appear.
+//   - `writable={false}` callers (share-token viewers) get an entry
+//     ribbon but no action cluster.
+
+import { Delete02Icon, Home02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { cn } from "@/lib/utils";
+import { chipForPath } from "./fileKindChip";
+
+export interface FileRowProps {
+  path: string;
+  size: string;
+  isEntry: boolean;
+  writable: boolean;
+  busy: boolean;
+  onSetEntry: () => void;
+  onDelete: () => void;
+}
+
+export function FileRow({
+  path,
+  size,
+  isEntry,
+  writable,
+  busy,
+  onSetEntry,
+  onDelete,
+}: FileRowProps) {
+  const desc = chipForPath(path);
+
+  return (
+    <li
+      aria-label={isEntry ? `${path} (entry page)` : path}
+      className={cn(
+        "group/row relative grid items-center gap-3 px-4 py-2 sm:px-5",
+        // Reservation columns: chip | path (flex) | size | actions/ribbon.
+        "grid-cols-[auto_minmax(0,1fr)_auto_auto]",
+        isEntry && "bg-folder-soft/30",
+      )}
+    >
+      {/* Entry stripe — a thin ink ribbon down the left edge. */}
+      {isEntry ? (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-1 left-0 w-[3px] rounded-full bg-primary/70"
+        />
+      ) : null}
+
+      <KindChip abbr={desc.abbr} label={desc.label} color={desc.color} fg={desc.fg} />
+
+      <span
+        className={cn(
+          "min-w-0 truncate font-mono text-xs",
+          isEntry ? "font-semibold text-foreground" : "text-foreground/85",
+        )}
+        title={path}
+      >
+        {path}
+      </span>
+
+      <span className="font-mono text-[10px] tabular-nums text-muted-foreground">{size}</span>
+
+      <div className="flex min-w-[5.25rem] items-center justify-end">
+        {isEntry ? (
+          <EntryRibbon />
+        ) : writable ? (
+          <RowActions onSetEntry={onSetEntry} onDelete={onDelete} disabled={busy} path={path} />
+        ) : (
+          <span aria-hidden className="block w-0" />
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ─── KindChip ────────────────────────────────────────────────────────
+
+function KindChip({
+  abbr,
+  label,
+  color,
+  fg,
+}: {
+  abbr: string;
+  label: string;
+  color: string;
+  fg: string;
+}) {
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      className="inline-grid size-[1.125rem] place-items-center rounded-[4px] font-heading text-[8px] font-bold uppercase tracking-tight ring-1 ring-border/40"
+      style={{ backgroundColor: color, color: fg }}
+    >
+      {abbr}
+    </span>
+  );
+}
+
+// ─── EntryRibbon ─────────────────────────────────────────────────────
+//
+// A handwritten "entry" washi-tape ribbon, sized to fit inside the
+// row. Inline emulation of `<TapeChip>`'s look without the rough.js
+// roundtrip (which would be wasteful on every list row); the chip
+// itself is a pill with the primary-accent fill and the Caveat hand.
+
+function EntryRibbon() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 font-hand text-sm leading-none text-primary ring-1 ring-primary/30"
+      style={{ transform: "rotate(-1.2deg)" }}
+    >
+      entry
+    </span>
+  );
+}
+
+// ─── RowActions ──────────────────────────────────────────────────────
+
+function RowActions({
+  path,
+  onSetEntry,
+  onDelete,
+  disabled,
+}: {
+  path: string;
+  onSetEntry: () => void;
+  onDelete: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100 focus-within:opacity-100">
+      <button
+        type="button"
+        className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:opacity-50"
+        title="Set as entry"
+        aria-label={`Set ${path} as entry`}
+        onClick={onSetEntry}
+        disabled={disabled}
+      >
+        <HugeiconsIcon icon={Home02Icon} className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        className="rounded p-1 text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:opacity-50"
+        title="Delete"
+        aria-label={`Delete ${path}`}
+        onClick={() => {
+          if (window.confirm(`Delete "${path}"? This cannot be undone.`)) {
+            onDelete();
+          }
+        }}
+        disabled={disabled}
+      >
+        <HugeiconsIcon icon={Delete02Icon} className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/features/editor/static-site/FilesList.tsx
+++ b/src/features/editor/static-site/FilesList.tsx
@@ -1,0 +1,128 @@
+// FilesList — paper-sheet panel listing every asset in a static-site
+// bundle. Wrapped in a rough.js silhouette so the panel reads as a
+// torn-from-the-pad sheet, then overlaid with paper-grain + fibre
+// dots for tooth.
+//
+// Pure presentation — receives a manifest and a handful of callbacks.
+// Sorts so the entry row appears first (this addresses a real
+// scannability problem: today the entry can sit mid-list when the
+// list is strictly alphabetical, so users hunt for it).
+
+import { useMemo } from "react";
+import { RoughBox } from "@/components/rough/RoughBox";
+import { EmptyDeskNote } from "@/components/sketch/EmptyDeskNote";
+import type { StaticSiteFileBlob } from "@/lib/api/client";
+import { FileRow } from "./FileRow";
+
+export interface FilesListProps {
+  id: string;
+  manifest: StaticSiteFileBlob;
+  totalLabel: string;
+  writable: boolean;
+  busy: boolean;
+  onSetEntry: (path: string) => void;
+  onDelete: (path: string) => void;
+}
+
+export function FilesList({
+  id,
+  manifest,
+  totalLabel,
+  writable,
+  busy,
+  onSetEntry,
+  onDelete,
+}: FilesListProps) {
+  const assets = manifest.assets;
+  const entry = manifest.entry;
+  const isEmpty = assets.length === 0;
+
+  // Entry-first, then alphabetical. The server already returns
+  // assets sorted alphabetically, so we just hoist the entry. This
+  // also means a paths-equal-to-entry-string fallback returns the
+  // first row, which is the same row we'd hoist; idempotent.
+  const sorted = useMemo(() => {
+    if (assets.length === 0) return assets;
+    const e = assets.find((a) => a.path === entry);
+    if (!e) return assets;
+    return [e, ...assets.filter((a) => a.path !== entry)];
+  }, [assets, entry]);
+
+  return (
+    <section aria-label="Files in bundle" className="relative isolate">
+      <RoughBox
+        shape="card"
+        seed={`files-card:${id}`}
+        stroke="var(--color-card-stroke)"
+        strokeWidth={1.3}
+        fill="var(--color-card)"
+        fillStyle="solid"
+        roughness={0.7}
+        bowing={0.5}
+        radius={10}
+      />
+      {/* Paper tooth — grain + sparse fibre dots. `-z-0` keeps them
+          above the rough.js silhouette but below the content. */}
+      <div
+        aria-hidden
+        className="bg-paper-grain pointer-events-none absolute inset-0 -z-0 rounded-md"
+      />
+      <div
+        aria-hidden
+        className="bg-paper-dots pointer-events-none absolute inset-0 -z-0 rounded-md"
+      />
+
+      <header className="relative flex items-center justify-between gap-2 px-4 pt-3 pb-2 sm:px-5">
+        <div className="flex items-center gap-2">
+          <h2 className="font-heading text-sm font-semibold">Files</h2>
+          <span className="font-hand text-base leading-none text-muted-foreground/80">
+            inside the bundle
+          </span>
+        </div>
+        <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+          {totalLabel}
+        </span>
+      </header>
+
+      <div aria-hidden className="relative mx-4 h-px bg-border/40 sm:mx-5" />
+
+      {isEmpty ? (
+        <div className="relative px-4 pb-6 sm:px-5">
+          <EmptyDeskNote
+            seed={`static-empty:${id}`}
+            title="No pages yet"
+            body={
+              writable
+                ? "Drop a .zip on the upload card to publish your first page."
+                : "This bundle is empty."
+            }
+          />
+        </div>
+      ) : (
+        <ul className="relative divide-y divide-border/30">
+          {sorted.map((a) => (
+            <FileRow
+              key={a.path}
+              path={a.path}
+              size={formatBytes(a.size)}
+              isEntry={a.path === entry}
+              writable={writable}
+              busy={busy}
+              onSetEntry={() => onSetEntry(a.path)}
+              onDelete={() => onDelete(a.path)}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// Local copy of the byte formatter — kept here so `FilesList` is
+// drop-in usable without importing from `StaticSiteEditor`.
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}

--- a/src/features/editor/static-site/SiteCard.tsx
+++ b/src/features/editor/static-site/SiteCard.tsx
@@ -1,0 +1,118 @@
+// SiteCard — the manila "label slip" that anchors the static-site
+// edit page. It carries the bundle's identity: entry filename, file
+// count, total size, and the primary "Open in new tab" CTA.
+//
+// Replaces the redundant ENTRY PAGE summary card in the original
+// design. The same information lives in two places no more — the
+// site card carries identity, the file list carries individual file
+// rows (the entry is signalled there with a ribbon + stripe, not a
+// duplicate filename).
+//
+// Visual: rough.js outlined card with `--folder-soft` fill so it
+// reads as a manila slip pinned to the desk, paper-grain overlay for
+// tooth, slight per-id tilt to feel hand-laid.
+
+import { LinkSquare01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { RoughBox } from "@/components/rough/RoughBox";
+import { tiltFromId } from "@/components/sketch/tilt";
+import { Button } from "@/components/ui/button";
+
+export interface SiteCardProps {
+  id: string;
+  entry: string;
+  isEmpty: boolean;
+  fileCount: number;
+  totalLabel: string;
+  onOpen: () => void;
+  openPending: boolean;
+}
+
+export function SiteCard({
+  id,
+  entry,
+  isEmpty,
+  fileCount,
+  totalLabel,
+  onOpen,
+  openPending,
+}: SiteCardProps) {
+  const tilt = tiltFromId(`site-card:${id}`, 0.4);
+  const fileNoun = fileCount === 1 ? "file" : "files";
+
+  return (
+    <section
+      aria-label="Site overview"
+      className="relative isolate"
+      style={{ transform: `rotate(${tilt}deg)` }}
+    >
+      <RoughBox
+        shape="card"
+        seed={`site-card:${id}`}
+        stroke="var(--color-card-stroke)"
+        strokeWidth={1.3}
+        fill="var(--color-folder-soft)"
+        fillStyle="solid"
+        roughness={0.9}
+        bowing={0.6}
+        radius={10}
+      />
+      <div
+        aria-hidden
+        className="bg-paper-grain pointer-events-none absolute inset-0 -z-0 rounded-md"
+      />
+
+      <div className="relative flex flex-col gap-4 p-5 sm:p-6">
+        <header className="flex items-center justify-between gap-2">
+          <span className="font-hand text-lg leading-none text-foreground/75">entry&nbsp;→</span>
+          <span className="inline-flex items-center rounded-full bg-card/70 px-2 py-0.5 font-sans text-[10px] uppercase tracking-[0.12em] text-muted-foreground ring-1 ring-border/40">
+            static site
+          </span>
+        </header>
+
+        <div className="min-w-0">
+          {isEmpty ? (
+            <span className="font-mono text-base italic text-muted-foreground">
+              no entry set yet
+            </span>
+          ) : (
+            <span className="block font-mono text-lg font-semibold leading-snug text-foreground break-all">
+              {entry}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip>
+            {fileCount} {fileNoun}
+          </Chip>
+          <Chip>{totalLabel}</Chip>
+        </div>
+
+        <div className="pt-1">
+          <Button
+            variant="default"
+            size="lg"
+            onClick={onOpen}
+            disabled={isEmpty || openPending}
+            aria-label="Open rendered site in a new tab"
+            title={
+              isEmpty ? "Upload files to enable preview" : "Open the rendered site in a new tab"
+            }
+          >
+            <HugeiconsIcon icon={LinkSquare01Icon} />
+            Open site in new tab
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-card/70 px-2.5 py-1 font-sans text-xs text-foreground ring-1 ring-border/40">
+      {children}
+    </span>
+  );
+}

--- a/src/features/editor/static-site/UploadPanel.tsx
+++ b/src/features/editor/static-site/UploadPanel.tsx
@@ -1,0 +1,269 @@
+// UploadPanel — rough.js outlined dropzone with three explicit upload
+// buttons. Lives next to (or below) the SiteCard so the primary
+// mutation surface stays reachable without scrolling past the file
+// list.
+//
+// Owns:
+//   - dragOver state
+//   - drop handler (with folder-aware FileSystem-Entry traversal)
+//   - three hidden `<input>` pickers (zip / folder / files)
+//   - the routing decision: a single dropped ZIP is treated as a
+//     "replace all", everything else merges
+//
+// Receives the two mutations (files / zip) plus the bundle id from
+// the parent so the editor stays the single source of truth for
+// version mirroring and `If-Match` semantics.
+
+import { FileUploadIcon, FolderUploadIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useCallback, useRef, useState } from "react";
+import { RoughBox } from "@/components/rough/RoughBox";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type UploadEntry = File | { path: string; file: File };
+
+export interface UploadPanelProps {
+  id: string;
+  isEmpty: boolean;
+  filesPending: boolean;
+  zipPending: boolean;
+  onUploadFiles: (entries: UploadEntry[]) => void;
+  onUploadZip: (zip: Blob) => void;
+}
+
+export function UploadPanel({
+  id,
+  isEmpty,
+  filesPending,
+  zipPending,
+  onUploadFiles,
+  onUploadZip,
+}: UploadPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const folderInputRef = useRef<HTMLInputElement | null>(null);
+  const zipInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [dragOver, setDragOver] = useState(false);
+
+  const onPickFiles = (list: FileList | null) => {
+    if (!list || list.length === 0) return;
+    const entries: UploadEntry[] = [];
+    for (const f of Array.from(list)) {
+      const rel = (f as File & { webkitRelativePath?: string }).webkitRelativePath;
+      if (rel && rel.length > 0) {
+        const stripped = rel.split("/").slice(1).join("/") || f.name;
+        entries.push({ path: stripped, file: f });
+      } else {
+        entries.push(f);
+      }
+    }
+    onUploadFiles(entries);
+  };
+
+  const onPickZip = (list: FileList | null) => {
+    if (!list || list.length === 0) return;
+    onUploadZip(list[0]);
+  };
+
+  const onDrop = useCallback(
+    async (e: React.DragEvent<HTMLElement>) => {
+      e.preventDefault();
+      setDragOver(false);
+      const dt = e.dataTransfer;
+      if (!dt) return;
+      const items = dt.items;
+      const collected: UploadEntry[] = [];
+      if (items && items.length > 0 && (items[0] as DataTransferItem).webkitGetAsEntry) {
+        const tasks: Promise<void>[] = [];
+        for (let i = 0; i < items.length; i++) {
+          const entry = (items[i] as DataTransferItem).webkitGetAsEntry?.();
+          if (entry) tasks.push(walkEntry(entry, "", collected));
+        }
+        await Promise.all(tasks);
+      } else {
+        for (const f of Array.from(dt.files)) collected.push(f);
+      }
+      if (collected.length === 0) return;
+      if (
+        collected.length === 1 &&
+        collected[0] instanceof File &&
+        /\.zip$/i.test(collected[0].name)
+      ) {
+        onUploadZip(collected[0]);
+        return;
+      }
+      onUploadFiles(collected);
+    },
+    [onUploadFiles, onUploadZip],
+  );
+
+  return (
+    <section
+      aria-label="Upload files"
+      className={cn(
+        "relative isolate rounded-md p-5 transition-shadow sm:p-6",
+        dragOver && "ring-2 ring-primary/40",
+      )}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={onDrop}
+    >
+      <RoughBox
+        shape="card"
+        seed={`upload:${id}`}
+        stroke={dragOver ? "var(--color-primary)" : "var(--color-card-stroke)"}
+        strokeWidth={1.3}
+        fill={dragOver ? "var(--color-accent)" : "var(--color-card)"}
+        fillStyle="solid"
+        roughness={1.2}
+        bowing={0.9}
+        radius={10}
+      />
+      <div
+        aria-hidden
+        className="bg-paper-grain pointer-events-none absolute inset-0 -z-0 rounded-md"
+      />
+
+      <div className="relative flex flex-col gap-4">
+        <header className="flex items-center justify-between gap-2">
+          <h2 className="font-heading text-sm font-semibold">Upload</h2>
+          <span
+            className={cn(
+              "font-hand text-base leading-none transition-colors",
+              dragOver ? "text-primary" : "text-muted-foreground/85",
+            )}
+          >
+            {dragOver ? "drop it!" : "drag a .zip, folder, or files here"}
+          </span>
+        </header>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => zipInputRef.current?.click()}
+            disabled={zipPending}
+          >
+            <HugeiconsIcon icon={FolderUploadIcon} />
+            Upload .zip {isEmpty ? null : "(replace all)"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => folderInputRef.current?.click()}
+            disabled={filesPending}
+          >
+            <HugeiconsIcon icon={FolderUploadIcon} />
+            Upload folder
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={filesPending}
+          >
+            <HugeiconsIcon icon={FileUploadIcon} />
+            Upload files
+          </Button>
+        </div>
+
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          Uploading a <code className="font-mono">.zip</code> replaces the entire bundle. Uploading
+          individual files or a folder merges into the existing bundle.
+        </p>
+
+        {/* Hidden inputs driven by the buttons above. */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          hidden
+          onChange={(e) => {
+            onPickFiles(e.currentTarget.files);
+            e.currentTarget.value = "";
+          }}
+        />
+        <input
+          ref={folderInputRef}
+          type="file"
+          multiple
+          hidden
+          // `webkitdirectory` is non-standard; React forwards it as an HTML
+          // attribute regardless. Cast the prop bag so the TS DOM types
+          // don't reject it.
+          {...({ webkitdirectory: "" } as Record<string, string>)}
+          onChange={(e) => {
+            onPickFiles(e.currentTarget.files);
+            e.currentTarget.value = "";
+          }}
+        />
+        <input
+          ref={zipInputRef}
+          type="file"
+          accept=".zip,application/zip"
+          hidden
+          onChange={(e) => {
+            onPickZip(e.currentTarget.files);
+            e.currentTarget.value = "";
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+// ─── Drag-and-drop folder walker ────────────────────────────────────
+//
+// FileSystem Entry API is non-standard but is the only DOM API that
+// preserves directory structure on drop. Chromium, WebKit and Gecko
+// all support it. We collect each leaf into a `{path, file}` pair so
+// the upload reaches the worker with the right asset relpath.
+
+type FsEntry = {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  file?: (cb: (f: File) => void, err?: (e: unknown) => void) => void;
+  createReader?: () => {
+    readEntries: (cb: (entries: FsEntry[]) => void, err?: (e: unknown) => void) => void;
+  };
+};
+
+async function walkEntry(entry: unknown, prefix: string, out: UploadEntry[]): Promise<void> {
+  if (!entry) return;
+  const e = entry as FsEntry;
+  if (e.isFile && e.file) {
+    await new Promise<void>((resolve) => {
+      e.file?.(
+        (f) => {
+          out.push({ path: prefix ? `${prefix}/${e.name}` : e.name, file: f });
+          resolve();
+        },
+        () => resolve(),
+      );
+    });
+    return;
+  }
+  if (e.isDirectory && e.createReader) {
+    const reader = e.createReader();
+    const children: FsEntry[] = [];
+    await new Promise<void>((resolve) => {
+      const drain = () =>
+        reader.readEntries((batch) => {
+          if (batch.length === 0) {
+            resolve();
+            return;
+          }
+          children.push(...batch);
+          drain();
+        });
+      drain();
+    });
+    const next = prefix ? `${prefix}/${e.name}` : e.name;
+    await Promise.all(children.map((c) => walkEntry(c, next, out)));
+  }
+}

--- a/src/features/editor/static-site/fileKindChip.ts
+++ b/src/features/editor/static-site/fileKindChip.ts
@@ -1,0 +1,146 @@
+// fileKindChip — derive a tiny coloured chip for a static-site asset
+// based on its file extension.
+//
+// The static-site editor renders one chip per file in the bundle so
+// users can scan-spot the HTML pages, the stylesheet, the script, the
+// images at a glance instead of having to read ten near-identical
+// monospace strings. Colours come from the existing `--color-tag-1..5`
+// decoration tokens (already theme-aware in `src/index.css`), with
+// folder/manila and muted neutrals as fallbacks so we never run out
+// of slots.
+//
+// Pure module — no React. Consumed by `FileRow.tsx`.
+
+export type AssetKind = "html" | "css" | "js" | "image" | "font" | "json" | "doc" | "other";
+
+export interface KindDescriptor {
+  /** Long label, used as accessible name + tooltip. */
+  label: string;
+  /** Two-character abbreviation rendered inside the chip. */
+  abbr: string;
+  /** CSS color expression (token reference). */
+  color: string;
+  /** Foreground color used by the abbreviation. */
+  fg: string;
+}
+
+const TABLE: Record<AssetKind, KindDescriptor> = {
+  // Pink — HTML pages are the "content" of a static site, the loudest
+  // slot is intentional.
+  html: {
+    label: "HTML page",
+    abbr: "HT",
+    color: "var(--color-tag-2)",
+    fg: "#1c1814",
+  },
+  // Blue — stylesheets.
+  css: {
+    label: "Stylesheet",
+    abbr: "CS",
+    color: "var(--color-tag-4)",
+    fg: "#1c1814",
+  },
+  // Yellow — scripts.
+  js: {
+    label: "Script",
+    abbr: "JS",
+    color: "var(--color-tag-1)",
+    fg: "#1c1814",
+  },
+  // Green — images / vector assets.
+  image: {
+    label: "Image",
+    abbr: "IM",
+    color: "var(--color-tag-3)",
+    fg: "#1c1814",
+  },
+  // Purple — fonts.
+  font: {
+    label: "Font",
+    abbr: "FN",
+    color: "var(--color-tag-5)",
+    fg: "#1c1814",
+  },
+  // Manila — data / source-maps. Reuses the folder token so it sits
+  // visually adjacent to the manila site card.
+  json: {
+    label: "Data",
+    abbr: "JN",
+    color: "var(--color-folder)",
+    fg: "#1c1814",
+  },
+  // Muted — documents (pdf / md / txt).
+  doc: {
+    label: "Document",
+    abbr: "DC",
+    color: "var(--color-muted)",
+    fg: "var(--color-muted-foreground)",
+  },
+  // Muted — fallback for anything unrecognised. Two dots so it reads
+  // as "something" rather than a missing label.
+  other: {
+    label: "File",
+    abbr: "··",
+    color: "var(--color-muted)",
+    fg: "var(--color-muted-foreground)",
+  },
+};
+
+/** Map a file path to its asset kind by extension. Lowercased; the
+ *  extension is whatever follows the last `.` in the path (case-
+ *  insensitive). Unknown extensions return `"other"`. */
+export function kindForPath(path: string): AssetKind {
+  const lower = path.toLowerCase();
+  const dot = lower.lastIndexOf(".");
+  const ext = dot === -1 ? "" : lower.slice(dot + 1);
+  switch (ext) {
+    case "html":
+    case "htm":
+    case "xhtml":
+      return "html";
+    case "css":
+      return "css";
+    case "js":
+    case "mjs":
+    case "cjs":
+    case "ts":
+    case "tsx":
+    case "jsx":
+      return "js";
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "gif":
+    case "webp":
+    case "svg":
+    case "avif":
+    case "ico":
+    case "bmp":
+      return "image";
+    case "woff":
+    case "woff2":
+    case "ttf":
+    case "otf":
+    case "eot":
+      return "font";
+    case "json":
+    case "map":
+    case "xml":
+    case "yaml":
+    case "yml":
+    case "toml":
+      return "json";
+    case "pdf":
+    case "md":
+    case "markdown":
+    case "txt":
+      return "doc";
+    default:
+      return "other";
+  }
+}
+
+/** Lookup the chip descriptor for a path in one call. */
+export function chipForPath(path: string): KindDescriptor {
+  return TABLE[kindForPath(path)];
+}

--- a/src/features/explorer/DashboardPage.tsx
+++ b/src/features/explorer/DashboardPage.tsx
@@ -182,6 +182,7 @@ export function DashboardPage() {
           targetType={shareTarget.kind}
           targetId={shareTarget.kind === "file" ? shareTarget.file.id : shareTarget.folder.id}
           targetName={shareTarget.kind === "file" ? shareTarget.file.name : shareTarget.folder.name}
+          targetKind={shareTarget.kind === "file" ? shareTarget.file.kind : undefined}
         />
       ) : null}
 
@@ -262,6 +263,8 @@ function defaultNameForKind(kind: FileKind): string {
       return "Untitled diagram";
     case "notes":
       return "Untitled note";
+    case "static-site":
+      return "Untitled site";
     default:
       return "Untitled drawing";
   }

--- a/src/features/explorer/dialogs/NewFileDialog.tsx
+++ b/src/features/explorer/dialogs/NewFileDialog.tsx
@@ -55,6 +55,11 @@ const CARDS: ReadonlyArray<KindCard> = [
     title: "Notes",
     description: "Rich text notes with headings, lists and embeds.",
   },
+  {
+    kind: "static-site",
+    title: "Static site",
+    description: "Upload HTML, CSS, and JS files (or a .zip) and share the rendered page.",
+  },
 ];
 
 export function NewFileDialog({ open, onOpenChange, onPick }: NewFileDialogProps) {
@@ -68,9 +73,9 @@ export function NewFileDialog({ open, onOpenChange, onPick }: NewFileDialogProps
         {/* Base UI's Dialog moves focus to the first focusable
          *  element on open, so the first card receives focus
          *  naturally without an explicit `autoFocus` attribute. */}
-        {/* Three cards — stacked single column on narrow screens, a
-         *  3-up grid from `sm` onwards so the picker stays compact. */}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {/* Four cards — stacked single column on the narrowest screens,
+         *  then a 2x2 grid from `sm` upward so the picker stays compact. */}
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {CARDS.map((c) => (
             <KindCardButton key={c.kind} card={c} onPick={() => onPick(c.kind)} />
           ))}

--- a/src/features/sharing/ShareDialog.tsx
+++ b/src/features/sharing/ShareDialog.tsx
@@ -40,7 +40,7 @@ import {
   useShareList,
   useUpdateShare,
 } from "@/data/shares";
-import type { ShareTargetType } from "@/lib/api/client";
+import type { FileKind, ShareTargetType } from "@/lib/api/client";
 import { copyToClipboard } from "@/lib/clipboard";
 import { errorMessage } from "@/lib/errors";
 import { shareUrl } from "@/lib/url";
@@ -53,6 +53,10 @@ interface ShareDialogProps {
   targetType: ShareTargetType;
   targetId: string;
   targetName: string;
+  /** File kind, only meaningful for `targetType === "file"`. Drives
+   *  kind-aware UX such as locking the permission selector for
+   *  static-site shares (which have no write path). */
+  targetKind?: FileKind;
 }
 
 export function ShareDialog({
@@ -61,7 +65,9 @@ export function ShareDialog({
   targetType,
   targetId,
   targetName,
+  targetKind,
 }: ShareDialogProps) {
+  const lockedToRead = targetType === "file" && targetKind === "static-site";
   const sharesQuery = useShareList(targetType, targetId, open);
   const createShare = useCreateShare(targetType, targetId);
   const updateShare = useUpdateShare(targetType, targetId);
@@ -105,7 +111,9 @@ export function ShareDialog({
           <DialogDescription>
             {targetType === "folder"
               ? "Anyone with a link can access files inside this folder. Edit links can also create, edit and delete files."
-              : "Anyone with a link can access this file. Edit links can also save changes back to it."}
+              : lockedToRead
+                ? "Anyone with a link can view this site."
+                : "Anyone with a link can access this file. Edit links can also save changes back to it."}
           </DialogDescription>
         </DialogHeader>
 
@@ -147,6 +155,7 @@ export function ShareDialog({
                   <ShareLinkRow
                     key={sh.token}
                     share={sh}
+                    lockedToRead={lockedToRead}
                     onEdit={async (patch) => {
                       await updateShare.mutateAsync({ token: sh.token, body: patch });
                     }}
@@ -175,6 +184,7 @@ export function ShareDialog({
               <ShareLinkCreateForm
                 pending={createShare.isPending}
                 resetSignal={resetSignal}
+                lockedToRead={lockedToRead}
                 onCreate={async (body) => {
                   try {
                     const sh = await createShare.mutateAsync(body);

--- a/src/features/sharing/ShareLinkCreateForm.tsx
+++ b/src/features/sharing/ShareLinkCreateForm.tsx
@@ -41,6 +41,7 @@ export function ShareLinkCreateForm({
   pending,
   onCreate,
   resetSignal,
+  lockedToRead = false,
 }: {
   pending: boolean;
   /** Called with the create body. The parent runs the mutation, copies
@@ -50,6 +51,9 @@ export function ShareLinkCreateForm({
   /** Bumping this number resets the form (e.g. when the dialog reopens
    *  with a different target). */
   resetSignal?: number;
+  /** When true, the permission selector is locked to "read" (e.g.
+   *  static-site file shares, which have no write path). */
+  lockedToRead?: boolean;
 }) {
   const [perm, setPerm] = useState<SharePermission>("read");
   const [allowDownload, setAllowDownload] = useState(true);
@@ -65,6 +69,13 @@ export function ShareLinkCreateForm({
     setExpiryId(DEFAULT_EXPIRY_ID);
     setLabel("");
   }, [resetSignal]);
+
+  // If the kind constraint flips on while the form is open, force
+  // perm back to read so a stale "write" selection can't slip into
+  // the submit body.
+  useEffect(() => {
+    if (lockedToRead && perm !== "read") setPerm("read");
+  }, [lockedToRead, perm]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -88,7 +99,7 @@ export function ShareLinkCreateForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      <PermissionSegment value={perm} onChange={setPerm} />
+      <PermissionSegment value={perm} onChange={setPerm} lockedToRead={lockedToRead} />
       <AllowDownloadField permission={perm} value={allowDownload} onChange={setAllowDownload} />
       <ExpiryChips
         options={EXPIRY_OPTIONS}

--- a/src/features/sharing/ShareLinkEditForm.tsx
+++ b/src/features/sharing/ShareLinkEditForm.tsx
@@ -51,12 +51,18 @@ export function ShareLinkEditForm({
   share,
   onCancel,
   onSave,
+  lockedToRead = false,
 }: {
   share: Share;
   onCancel: () => void;
   onSave: (patch: ShareLinkEditPatch) => Promise<void>;
+  /** When true, permission is locked to "read" — used for static-site
+   *  shares. Defensive against legacy rows whose persisted permission
+   *  is "write": we surface them as "read" and the patch will
+   *  downgrade them on save. */
+  lockedToRead?: boolean;
 }) {
-  const [perm, setPerm] = useState<SharePermission>(share.permission);
+  const [perm, setPerm] = useState<SharePermission>(lockedToRead ? "read" : share.permission);
   const [allowDownload, setAllowDownload] = useState<boolean>(share.allowDownload);
   const [expiry, setExpiry] = useState<ExpiryChoice>("keep");
   const [label, setLabel] = useState<string>(share.label ?? "");
@@ -104,7 +110,7 @@ export function ShareLinkEditForm({
       onSubmit={handleSubmit}
       className="flex flex-col gap-4 rounded-lg bg-muted/30 p-4 ring-1 ring-border/50"
     >
-      <PermissionSegment value={perm} onChange={setPerm} />
+      <PermissionSegment value={perm} onChange={setPerm} lockedToRead={lockedToRead} />
       <AllowDownloadField permission={perm} value={allowDownload} onChange={setAllowDownload} />
       <ExpiryChips
         options={EXPIRY_OPTIONS}

--- a/src/features/sharing/ShareLinkRow.tsx
+++ b/src/features/sharing/ShareLinkRow.tsx
@@ -44,9 +44,19 @@ export interface ShareLinkRowProps {
   onRevoke: () => Promise<void>;
   /** Optional class name for the outer card. */
   className?: string;
+  /** When true, the inline edit form locks the permission selector
+   *  to "read". Used for static-site file shares. */
+  lockedToRead?: boolean;
 }
 
-export function ShareLinkRow({ share, onEdit, onRotate, onRevoke, className }: ShareLinkRowProps) {
+export function ShareLinkRow({
+  share,
+  onEdit,
+  onRotate,
+  onRevoke,
+  className,
+  lockedToRead = false,
+}: ShareLinkRowProps) {
   const [editing, setEditing] = useState(false);
 
   const url = shareUrl(share.token);
@@ -130,7 +140,12 @@ export function ShareLinkRow({ share, onEdit, onRotate, onRevoke, className }: S
 
       {/* Edit form OR meta+actions */}
       {editing ? (
-        <ShareLinkEditForm share={share} onCancel={() => setEditing(false)} onSave={handleSave} />
+        <ShareLinkEditForm
+          share={share}
+          onCancel={() => setEditing(false)}
+          onSave={handleSave}
+          lockedToRead={lockedToRead}
+        />
       ) : (
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">

--- a/src/features/sharing/fields/PermissionSegment.tsx
+++ b/src/features/sharing/fields/PermissionSegment.tsx
@@ -2,30 +2,51 @@
 // the create and edit forms; the visual contract (border + active
 // background, title + subtitle) must stay in sync between them so the
 // two flows feel identical.
+//
+// `lockedToRead` is a kind-aware lock: when true, the "Can edit"
+// segment is disabled (and the wrapping form is responsible for
+// forcing `value` to "read" so a click can't desync state). Used
+// today for static-site shares, which have no write path on the
+// share-token side.
 
 import type { SharePermission } from "@/lib/api/client";
 
 export function PermissionSegment({
   value,
   onChange,
+  lockedToRead = false,
+  lockedReason,
 }: {
   value: SharePermission;
   onChange: (next: SharePermission) => void;
+  lockedToRead?: boolean;
+  /** Short explanation shown under the segments when locked. */
+  lockedReason?: string;
 }) {
   return (
-    <div className="grid grid-cols-2 gap-2">
-      <Segment
-        active={value === "read"}
-        onClick={() => onChange("read")}
-        title="View only"
-        subtitle="Read-only access."
-      />
-      <Segment
-        active={value === "write"}
-        onClick={() => onChange("write")}
-        title="Can edit"
-        subtitle="Read-write access."
-      />
+    <div className="flex flex-col gap-1.5">
+      <div className="grid grid-cols-2 gap-2">
+        <Segment
+          active={value === "read"}
+          onClick={() => onChange("read")}
+          title="View only"
+          subtitle="Read-only access."
+        />
+        <Segment
+          active={value === "write"}
+          onClick={() => {
+            if (!lockedToRead) onChange("write");
+          }}
+          title="Can edit"
+          subtitle="Read-write access."
+          disabled={lockedToRead}
+        />
+      </div>
+      {lockedToRead ? (
+        <p className="text-xs text-muted-foreground">
+          {lockedReason ?? "Static sites can only be shared view-only."}
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -35,18 +56,22 @@ function Segment({
   onClick,
   title,
   subtitle,
+  disabled = false,
 }: {
   active: boolean;
   onClick: () => void;
   title: string;
   subtitle: string;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       data-active={active}
-      className="rounded-md border border-border bg-background px-3 py-2.5 text-left transition-colors data-[active=true]:border-ring data-[active=true]:bg-accent data-[active=true]:text-accent-foreground hover:bg-accent/40"
+      disabled={disabled}
+      aria-disabled={disabled}
+      className="rounded-md border border-border bg-background px-3 py-2.5 text-left transition-colors data-[active=true]:border-ring data-[active=true]:bg-accent data-[active=true]:text-accent-foreground hover:bg-accent/40 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background"
     >
       <div className="text-sm font-medium">{title}</div>
       <div className="text-xs text-muted-foreground">{subtitle}</div>

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -39,7 +39,7 @@ export interface Invite {
   revokedAt: number | null;
 }
 
-export type FileKind = "excalidraw" | "drawio" | "notes";
+export type FileKind = "excalidraw" | "drawio" | "notes" | "static-site";
 
 export interface FileMeta {
   id: string;
@@ -120,7 +120,28 @@ export interface NotesFileBlob {
   blocks: unknown[];
 }
 
-export type FileBlob = ExcalidrawFileBlob | DrawioFileBlob | NotesFileBlob;
+/** One asset inside a static-site bundle. Paths are forward-slash,
+ *  no leading slash, no `..`, no empty segments. */
+export interface StaticSiteAsset {
+  path: string;
+  size: number;
+  contentType: string;
+  /** unix-ms of the most recent upload of this asset. */
+  updatedAt: number;
+}
+
+/** Manifest for a `kind === "static-site"` file. Mutations go through
+ *  the dedicated `/api/files/:id/assets*` endpoints — direct PUT of
+ *  this manifest is rejected by the worker. */
+export interface StaticSiteFileBlob {
+  kind: "static-site";
+  /** Asset path served for the root request. Must exist in `assets`. */
+  entry: string;
+  /** Sorted alphabetically by path. */
+  assets: StaticSiteAsset[];
+}
+
+export type FileBlob = ExcalidrawFileBlob | DrawioFileBlob | NotesFileBlob | StaticSiteFileBlob;
 
 export interface LoadedFile {
   meta: {
@@ -403,6 +424,111 @@ export const files = {
     request<{ ok: true }>(`/api/files/${id}/shares/${token}`, { method: "DELETE" }),
 };
 
+// Static-site mutators for `kind === "static-site"` files. The worker
+// rejects raw `PUT /api/files/:id` for this kind — use these endpoints
+// so the manifest and the R2 objects stay in lockstep. All writes
+// return `{ meta, manifest }` so callers can patch both the file-list
+// cache and the editor tree without an extra round trip.
+
+export interface StaticSiteRenderSession {
+  /** Absolute URL prefix (with trailing slash) for the signed render
+   *  route. Concat `manifest.entry` to get the iframe `src`. */
+  prefix: string;
+  /** unix-ms when the signature expires. */
+  expiresAt: number;
+}
+
+export interface StaticSiteMutationResult {
+  meta: FileMeta;
+  manifest: StaticSiteFileBlob;
+}
+
+export const staticSites = {
+  /** Convenience read of the manifest. Same JSON as `files.load` but
+   *  skips the binary-response header dance. */
+  manifest: (id: string) => request<StaticSiteFileBlob>(`/api/files/${id}/manifest`),
+
+  /** Upload one or more files. Bare `File` keeps the file's own name
+   *  as the asset path; `{path, file}` lets the caller override
+   *  (e.g. preserving `webkitRelativePath` for dropped folders).
+   *  Pass `version` to enable optimistic-concurrency. */
+  async uploadAssets(
+    id: string,
+    files: Array<File | { path: string; file: File }>,
+    version?: number,
+  ): Promise<StaticSiteMutationResult> {
+    const fd = new FormData();
+    for (const entry of files) {
+      if (entry instanceof File) {
+        fd.append("file", entry, entry.name);
+      } else {
+        fd.append("file", entry.file, entry.path);
+      }
+    }
+    const headers: Record<string, string> = {};
+    if (typeof version === "number") headers["if-match"] = `"${version}"`;
+    const resp = await fetch(`/api/files/${id}/assets`, {
+      method: "POST",
+      credentials: "include",
+      headers,
+      body: fd,
+    });
+    return await unwrapStaticSiteResp(resp);
+  },
+
+  /** Replace the entire site with the contents of a ZIP. */
+  async uploadZip(id: string, zip: Blob, version?: number): Promise<StaticSiteMutationResult> {
+    const headers: Record<string, string> = { "content-type": "application/zip" };
+    if (typeof version === "number") headers["if-match"] = `"${version}"`;
+    const resp = await fetch(`/api/files/${id}/assets/zip`, {
+      method: "POST",
+      credentials: "include",
+      headers,
+      body: zip,
+    });
+    return await unwrapStaticSiteResp(resp);
+  },
+
+  async deleteAsset(id: string, path: string, version?: number): Promise<StaticSiteMutationResult> {
+    const headers: Record<string, string> = {};
+    if (typeof version === "number") headers["if-match"] = `"${version}"`;
+    const resp = await fetch(
+      `/api/files/${id}/assets/${path.split("/").map(encodeURIComponent).join("/")}`,
+      { method: "DELETE", credentials: "include", headers },
+    );
+    return await unwrapStaticSiteResp(resp);
+  },
+
+  async setEntry(id: string, path: string, version?: number): Promise<StaticSiteMutationResult> {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (typeof version === "number") headers["if-match"] = `"${version}"`;
+    const resp = await fetch(`/api/files/${id}/entry`, {
+      method: "PUT",
+      credentials: "include",
+      headers,
+      body: JSON.stringify({ path }),
+    });
+    return await unwrapStaticSiteResp(resp);
+  },
+
+  /** Mint a render session for the owner's preview iframe. */
+  renderSession: (id: string) =>
+    postJson<StaticSiteRenderSession>(`/api/files/${id}/render-session`, {}),
+};
+
+async function unwrapStaticSiteResp(resp: Response): Promise<StaticSiteMutationResult> {
+  if (!resp.ok) {
+    let payload: { error?: string } | null = null;
+    try {
+      payload = await resp.json();
+    } catch {
+      /* */
+    }
+    throw new ApiError(resp.status, payload?.error || `HTTP ${resp.status}`, payload);
+  }
+  return (await resp.json()) as StaticSiteMutationResult;
+}
+
 // ─── Shares (cross-target) ────────────────────────────────────────────
 export const shares = {
   /** All of caller's active shares (files + folders), with target name. */
@@ -518,6 +644,16 @@ export const shares = {
   folderFileDownloadUrl: (token: string, fileId: string) =>
     `/api/share/${token}/files/${fileId}/download`,
   fileThumbUrl: (token: string) => `/api/share/${token}/thumb`,
+
+  /** Mint a short-lived render session for a static-site file share. */
+  renderSession: (token: string) =>
+    postJson<StaticSiteRenderSession>(`/api/share/${token}/render-session`, {}),
+
+  /** Mint a short-lived render session for a static-site file inside a
+   *  folder share. The token must point at the parent folder share;
+   *  `fileId` must be in the folder subtree. */
+  renderSessionForFile: (token: string, fileId: string) =>
+    postJson<StaticSiteRenderSession>(`/api/share/${token}/files/${fileId}/render-session`, {}),
 };
 
 // ─── Internal helpers ─────────────────────────────────────────────────

--- a/src/lib/api/query-keys.ts
+++ b/src/lib/api/query-keys.ts
@@ -30,6 +30,10 @@ export const keys = {
     list: (q: FilesQuery) => ["files", "list", q] as const,
     detail: (id: string) => ["files", "detail", id] as const,
     shares: (fileId: string) => ["files", fileId, "shares"] as const,
+    /** Static-site manifest for the editor tree. Separate from
+     *  `detail` so a manifest mutation doesn't blow up the cached
+     *  `LoadedFile` and force the editor to remount. */
+    manifest: (fileId: string) => ["files", fileId, "manifest"] as const,
   },
 
   sharesAll: ["shares"] as const,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,11 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-// During `vite dev` we proxy /api to a locally-running Worker (`wrangler dev`).
-// In production the Worker serves the built SPA directly via the [assets] binding.
+// During `vite dev` we proxy /api, /sites, and /shared to a locally-running
+// Worker (`wrangler dev`). /sites and /shared serve signed static-site
+// asset bundles (owner-minted and share-token-minted respectively); see
+// worker/routes/render.ts. In production the Worker serves the built SPA
+// directly via the [assets] binding.
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -17,6 +20,14 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       "/api": {
+        target: "http://127.0.0.1:8888",
+        changeOrigin: true,
+      },
+      "/sites": {
+        target: "http://127.0.0.1:8888",
+        changeOrigin: true,
+      },
+      "/shared": {
         target: "http://127.0.0.1:8888",
         changeOrigin: true,
       },

--- a/worker/db/schema.ts
+++ b/worker/db/schema.ts
@@ -120,7 +120,7 @@ export const files = sqliteTable(
       onDelete: "set null",
     }),
     name: text("name").notNull().default("Untitled"),
-    kind: text("kind", { enum: ["excalidraw", "drawio", "notes"] })
+    kind: text("kind", { enum: ["excalidraw", "drawio", "notes", "static-site"] })
       .notNull()
       .default("excalidraw"),
     version: integer("version").notNull().default(1),

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -15,6 +15,7 @@ import foldersRoutes from "./routes/folders";
 import invitesRoutes from "./routes/invites";
 import meRoutes from "./routes/me";
 import publicShareRoutes from "./routes/public-share";
+import { ownerSites, sharedSites } from "./routes/render";
 import { fileSharesNested, folderSharesNested, sharesRoot } from "./routes/shares";
 import tagsRoutes from "./routes/tags";
 
@@ -36,6 +37,19 @@ app.route("/api/files", filesRoutes);
 app.route("/api/tags", tagsRoutes);
 app.route("/api/shares", sharesRoot);
 app.route("/api/share", publicShareRoutes);
+// Static-site asset serving (signature-gated, session-less). Mounted
+// at top-level paths OUTSIDE `/api/` so the URL the user sees in
+// "Open in new tab" looks like a site URL, not an API call:
+//
+//   /sites/:id/:sig/<path>      — owner-minted
+//   /shared/:token/:sig/<path>  — share-token-minted
+//
+// The worker `fetch` handler below routes `/sites/*` and `/shared/*`
+// to Hono alongside `/api/*`. The two flavors are intentionally
+// separate Hono routers — see worker/routes/render.ts for the
+// access-control invariants that depend on this split.
+app.route("/sites", ownerSites);
+app.route("/shared", sharedSites);
 // Nested share routers under file/folder owner namespaces. These mount
 // AFTER the resource routers so unrelated method+path combos within
 // the resource don't get shadowed.
@@ -62,7 +76,11 @@ app.notFound(
 export default {
   async fetch(req: Request, env: AppEnv["Bindings"], ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
-    if (url.pathname.startsWith("/api/")) {
+    if (
+      url.pathname.startsWith("/api/") ||
+      url.pathname.startsWith("/sites/") ||
+      url.pathname.startsWith("/shared/")
+    ) {
       return await app.fetch(req, env, ctx);
     }
     // Everything else — serve the SPA via the ASSETS binding.

--- a/worker/lib/crypto.ts
+++ b/worker/lib/crypto.ts
@@ -62,3 +62,60 @@ export function timingSafeEqual(a: string, b: string): boolean {
   }
   return diff === 0;
 }
+
+// ─── Render-session signatures ───────────────────────────────
+//
+// Used by `/sites/...` and `/shared/...` to gate access to static-site assets
+// without requiring the session cookie inside the sandboxed iframe.
+// The signature shape is `<hmac>.<exp>` where `<exp>` is unix-ms.
+//
+// `payload` should encode (id, who-the-signature-was-minted-for) so a
+// signature minted for one owner/share can't be replayed to read
+// another file. The render route reconstructs the exact same payload
+// and verifies.
+
+export interface RenderSig {
+  sig: string; // hmac.expMs
+  expiresAt: number;
+}
+
+const RENDER_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export async function signRender(
+  secret: string,
+  payload: string,
+  ttlMs: number = RENDER_TTL_MS,
+): Promise<RenderSig> {
+  const expiresAt = Date.now() + ttlMs;
+  const mac = await hmacSha256(secret, `${payload}|${expiresAt}`);
+  return { sig: `${mac}.${expiresAt}`, expiresAt };
+}
+
+/** Verify a render signature against the expected payload. Returns true
+ *  on success, false on any malformed-token / expired / mismatched
+ *  outcome. Constant-time on the HMAC compare. */
+export async function verifyRender(
+  secret: string,
+  sig: string,
+  payload: string,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const dot = sig.lastIndexOf(".");
+  if (dot < 0) return false;
+  const mac = sig.slice(0, dot);
+  const expStr = sig.slice(dot + 1);
+  const exp = Number(expStr);
+  if (!Number.isFinite(exp) || exp <= nowMs) return false;
+  const expected = await hmacSha256(secret, `${payload}|${exp}`);
+  return timingSafeEqual(mac, expected);
+}
+
+/** Stable payload string for an owner-minted render signature. */
+export function ownerRenderPayload(fileId: string, ownerId: string): string {
+  return `owner|${fileId}|${ownerId}`;
+}
+
+/** Stable payload string for a share-minted render signature. */
+export function shareRenderPayload(token: string, fileId: string): string {
+  return `share|${token}|${fileId}`;
+}

--- a/worker/lib/responses.ts
+++ b/worker/lib/responses.ts
@@ -6,6 +6,8 @@
 // response shapes (the `{error}` envelope, R2-cached thumbnails, file
 // downloads) live in one place rather than being copy-pasted.
 
+import { zipSync } from "fflate";
+import { isStaticSiteBlob, r2StaticSiteAssetKey } from "../services/static-site";
 import type { FileBlob, FileKind, FileRow } from "../types";
 import { assertNever } from "./util";
 
@@ -103,6 +105,28 @@ export async function streamFileResponse(
       headers["content-type"] = "application/xml; charset=utf-8";
       return new Response(parsed.xml, { headers });
     }
+    if (row.kind === "static-site") {
+      // Re-package the site's R2 assets into a single ZIP. The
+      // manifest blob lists every asset path, so we fan-out R2 reads
+      // and feed the result to fflate. `zipSync` is memory-bounded by
+      // the 100 MB site cap — within Workers limits but tight; if it
+      // becomes a problem we can switch to the streaming `Zip` API.
+      const manifest = await parseStoredFileBlob(obj);
+      if (!manifest || !isStaticSiteBlob(manifest)) {
+        return errorResponse(500, "invalid static-site manifest");
+      }
+      const entries: Record<string, Uint8Array> = {};
+      for (const a of manifest.assets) {
+        const assetObj = await env.R2.get(r2StaticSiteAssetKey(row.id, a.path));
+        if (!assetObj) {
+          return errorResponse(500, `missing asset "${a.path}" in R2`);
+        }
+        entries[a.path] = new Uint8Array(await assetObj.arrayBuffer());
+      }
+      const zip = zipSync(entries);
+      headers["content-type"] = "application/zip";
+      return new Response(zip, { headers });
+    }
   }
   return new Response(obj.body, { headers });
 }
@@ -125,7 +149,7 @@ function safeFilename(name: string): string {
   return base.slice(0, 80);
 }
 
-function downloadExtensionForKind(kind: FileKind): "excalidraw" | "drawio" | "notes.json" {
+function downloadExtensionForKind(kind: FileKind): "excalidraw" | "drawio" | "notes.json" | "zip" {
   switch (kind) {
     case "drawio":
       return "drawio";
@@ -139,6 +163,9 @@ function downloadExtensionForKind(kind: FileKind): "excalidraw" | "drawio" | "no
       // separate client-only "Export as Markdown" path that runs
       // `editor.blocksToMarkdownLossy()` in the browser.
       return "notes.json";
+    case "static-site":
+      // Re-packaged ZIP — see `streamFileResponse` for the build.
+      return "zip";
     default:
       return assertNever(kind);
   }

--- a/worker/routes/files.ts
+++ b/worker/routes/files.ts
@@ -12,12 +12,13 @@
 // should send `If-Match: <version>`; mismatch returns 409 with the
 // current row.
 
+import { unzipSync } from "fflate";
 import { Hono } from "hono";
 import * as filesRepo from "../db/repos/files";
 import * as foldersRepo from "../db/repos/folders";
 import * as sharesRepo from "../db/repos/shares";
 import * as tagsRepo from "../db/repos/tags";
-import { newId } from "../lib/crypto";
+import { newId, ownerRenderPayload, signRender } from "../lib/crypto";
 import {
   errorResponse,
   jsonResponse,
@@ -35,10 +36,29 @@ import {
   MAX_THUMB_BYTES,
   mirrorRenameIntoExcalidrawBlob,
   putFileBlob,
-  seedBlobForKind,
+  seedManifestForKind,
   writeR2Blob,
 } from "../services/file-blob";
-import type { FileKind, FileMeta, FileRow } from "../types";
+import {
+  applyDelete,
+  applyReplaceAll,
+  applySetEntry,
+  applyUpserts,
+  commitManifest,
+  contentTypeForPath,
+  deleteAllStaticSiteAssets,
+  deletePendingPaths,
+  MAX_SITE_ASSET_BYTES,
+  MAX_SITE_ASSET_COUNT,
+  MAX_SITE_TOTAL_BYTES,
+  type PendingAsset,
+  readManifest,
+  StaticSiteError,
+  validateAssetPath,
+  writePendingAssets,
+  writeSeedSite,
+} from "../services/static-site";
+import type { FileKind, FileMeta, FileRow, StaticSiteFileBlob } from "../types";
 import { normalizeFileKind, rowToMeta } from "../types";
 
 const r = new Hono<AppEnv>();
@@ -133,9 +153,20 @@ r.post("/", async (c) => {
   const ts = now();
   const name = (body.name || "Untitled").slice(0, 200);
   const kind = normalizeFileKind(body.kind);
-  const seed = seedBlobForKind(kind, name);
-  const seedBytes = new TextEncoder().encode(JSON.stringify(seed));
-  await writeR2Blob(c.env, id, seedBytes);
+
+  // Static-site uses a two-phase seed (R2 asset + manifest); the other
+  // kinds bundle everything into one JSON blob. See
+  // worker/services/file-blob.ts for the contract.
+  let seedBytes: number;
+  if (kind === "static-site") {
+    const seeded = await writeSeedSite(c.env, id, name);
+    seedBytes = seeded.bytes;
+  } else {
+    const seed = seedManifestForKind(kind, name);
+    const seedBuf = new TextEncoder().encode(JSON.stringify(seed));
+    await writeR2Blob(c.env, id, seedBuf);
+    seedBytes = seedBuf.byteLength;
+  }
 
   await filesRepo.insert(c.env, {
     id,
@@ -144,7 +175,7 @@ r.post("/", async (c) => {
     name,
     kind,
     version: 1,
-    size_bytes: seedBytes.byteLength,
+    size_bytes: seedBytes,
     has_thumb: false,
     thumb_updated_at: 0,
     created_at: ts,
@@ -162,7 +193,7 @@ r.post("/", async (c) => {
     kind,
     tags,
     version: 1,
-    sizeBytes: seedBytes.byteLength,
+    sizeBytes: seedBytes,
     hasThumb: false,
     thumbUpdatedAt: 0,
     activeShareCount: 0,
@@ -339,6 +370,331 @@ r.get("/:id/thumb", async (c) => {
   const id = c.req.param("id");
   return await serveR2WithCache(c.env, c.executionCtx ?? null, c.req.raw, r2ThumbKey(id));
 });
+
+// ─── Static-site asset endpoints ────────────────────────────────────
+//
+// All four mutators share the same shape:
+//   1. Load the file row, verify ownership + kind.
+//   2. Read the current manifest from R2.
+//   3. (`If-Match` precheck, mirroring the existing PUT contract.)
+//   4. Mutate the manifest in memory via a `static-site.ts` helper
+//      (throws `StaticSiteError` on validation failure).
+//   5. Write any R2 objects (or remove them).
+//   6. `commitManifest` writes the new manifest and bumps `version`,
+//      `size_bytes`, `updated_at` on the row.
+//   7. Return the refreshed `FileMeta` plus the new manifest.
+
+async function loadStaticSite(
+  env: AppEnv["Bindings"],
+  owner: string,
+  id: string,
+): Promise<{ row: FileRow; manifest: StaticSiteFileBlob } | Response> {
+  const row = await filesRepo.findById(env, owner, id);
+  if (!row) return errorResponse(404, "file not found");
+  if (row.kind !== "static-site") return errorResponse(400, "file is not a static-site");
+  const manifest = await readManifest(env, id);
+  if (!manifest) return errorResponse(500, "manifest missing or invalid");
+  return { row, manifest };
+}
+
+function checkIfMatch(req: Request, row: FileRow): Response | null {
+  const ifMatch = req.headers.get("if-match");
+  if (ifMatch === null) return null;
+  const wanted = ifMatch.replace(/^"|"$/g, "");
+  if (wanted !== String(row.version)) {
+    return jsonResponse(
+      { error: "version mismatch", currentVersion: row.version },
+      { status: 409 },
+    );
+  }
+  return null;
+}
+
+async function siteResponse(
+  env: AppEnv["Bindings"],
+  owner: string,
+  row: FileRow,
+  manifest: StaticSiteFileBlob,
+  committed: { version: number; sizeBytes: number; updatedAt: number },
+): Promise<Response> {
+  const tags = await tagsRepo.listForEntity(env, "file", row.id);
+  const shareMap = await sharesRepo.countActiveByTarget(env, owner, "file", [row.id]);
+  const meta: FileMeta = {
+    id: row.id,
+    folderId: row.folder_id ?? null,
+    name: row.name,
+    kind: row.kind,
+    tags,
+    version: committed.version,
+    sizeBytes: committed.sizeBytes,
+    hasThumb: row.has_thumb,
+    thumbUpdatedAt: row.thumb_updated_at,
+    activeShareCount: shareMap.get(row.id) ?? 0,
+    createdAt: row.created_at,
+    updatedAt: committed.updatedAt,
+  };
+  return jsonResponse({ meta, manifest });
+}
+
+// GET /api/files/:id/manifest — convenience read for the editor tree.
+// (The existing GET /api/files/:id already returns the same JSON, but
+// this endpoint skips the `x-file-*` header dance and 415-on-binary-body
+// expectations.)
+r.get("/:id/manifest", async (c) => {
+  const owner = c.get("session").userId;
+  const id = c.req.param("id");
+  const loaded = await loadStaticSite(c.env, owner, id);
+  if (loaded instanceof Response) return loaded;
+  return jsonResponse(loaded.manifest);
+});
+
+// POST /api/files/:id/assets — multipart upload of one or more files.
+//
+// Each `file` part's `filename` is treated as the asset relpath
+// (browsers can use `formData.append("file", file, file.webkitRelativePath)`
+// to preserve folder structure when the user drops a directory).
+//
+// Replace-or-append semantics per path. Validation runs against the
+// *post-mutation* manifest before any R2 write so a 413/400 reply
+// leaves R2 unchanged.
+r.post("/:id/assets", async (c) => {
+  const owner = c.get("session").userId;
+  const id = c.req.param("id");
+  const loaded = await loadStaticSite(c.env, owner, id);
+  if (loaded instanceof Response) return loaded;
+  const { row, manifest } = loaded;
+
+  const mismatch = checkIfMatch(c.req.raw, row);
+  if (mismatch) return mismatch;
+
+  // Cheap precheck: refuse outsized request bodies before parsing.
+  const cl = Number(c.req.header("content-length") || "0");
+  if (cl > MAX_SITE_TOTAL_BYTES) {
+    return errorResponse(413, `upload exceeds ${MAX_SITE_TOTAL_BYTES} bytes`);
+  }
+
+  let parsed: Awaited<ReturnType<typeof c.req.parseBody>>;
+  try {
+    parsed = await c.req.parseBody({ all: true });
+  } catch {
+    return errorResponse(400, "invalid multipart body");
+  }
+
+  const pending: PendingAsset[] = [];
+  // `c.req.parseBody({ all: true })` returns arrays for repeated keys.
+  // Accept any field that resolves to a File-ish value.
+  for (const value of Object.values(parsed)) {
+    const items = Array.isArray(value) ? value : [value];
+    for (const item of items) {
+      if (!(item instanceof File)) continue;
+      const path = item.name;
+      const err = validateAssetPath(path);
+      if (err) return errorResponse(400, `asset "${path}": ${err}`);
+      if (item.size > MAX_SITE_ASSET_BYTES) {
+        return errorResponse(413, `asset "${path}" exceeds ${MAX_SITE_ASSET_BYTES} bytes`);
+      }
+      const bytes = new Uint8Array(await item.arrayBuffer());
+      pending.push({
+        path,
+        bytes,
+        contentType: contentTypeForPath(path),
+      });
+    }
+  }
+  if (pending.length === 0) return errorResponse(400, "no files in request");
+  if (pending.length > MAX_SITE_ASSET_COUNT) {
+    return errorResponse(413, `too many files (max ${MAX_SITE_ASSET_COUNT})`);
+  }
+
+  let nextManifest: StaticSiteFileBlob;
+  try {
+    nextManifest = applyUpserts(manifest, pending);
+  } catch (e) {
+    if (e instanceof StaticSiteError) return errorResponse(e.status, e.message);
+    throw e;
+  }
+
+  await writePendingAssets(c.env, id, pending);
+  const committed = await commitManifest(c.env, row, nextManifest);
+  return siteResponse(c.env, owner, row, nextManifest, committed);
+});
+
+// POST /api/files/:id/assets/zip — raw ZIP body, replace mode.
+//
+// The whole prior asset set is dropped; any single top-level directory
+// in the ZIP is stripped so `mybundle/index.html` becomes `index.html`.
+// If the existing `entry` survives the upload it stays as entry;
+// otherwise the shallowest .html file in the new bundle is picked.
+r.post("/:id/assets/zip", async (c) => {
+  const owner = c.get("session").userId;
+  const id = c.req.param("id");
+  const loaded = await loadStaticSite(c.env, owner, id);
+  if (loaded instanceof Response) return loaded;
+  const { row, manifest } = loaded;
+
+  const mismatch = checkIfMatch(c.req.raw, row);
+  if (mismatch) return mismatch;
+
+  const cl = Number(c.req.header("content-length") || "0");
+  if (cl > MAX_SITE_TOTAL_BYTES) {
+    return errorResponse(413, `upload exceeds ${MAX_SITE_TOTAL_BYTES} bytes`);
+  }
+
+  const buf = await c.req.raw.arrayBuffer();
+  if (buf.byteLength === 0) return errorResponse(400, "empty body");
+
+  let raw: Record<string, Uint8Array>;
+  try {
+    raw = unzipSync(new Uint8Array(buf));
+  } catch {
+    return errorResponse(400, "invalid ZIP");
+  }
+
+  // Drop ZIP directory entries (paths ending in `/`) and any empty
+  // keys before any further processing. Many `zip -r` flavors emit
+  // explicit directory entries; treating them as files would either
+  // trip path validation or pollute the common-prefix scan.
+  const entries: Record<string, Uint8Array> = {};
+  for (const [path, bytes] of Object.entries(raw)) {
+    if (!path || path.endsWith("/")) continue;
+    entries[path] = bytes;
+  }
+
+  // Strip a single common top-level directory, if any. This matches
+  // richdoc's export shape (`out.zip` containing `out/index.html`).
+  const stripped = stripCommonPrefix(entries);
+
+  const pending: PendingAsset[] = [];
+  for (const [path, bytes] of Object.entries(stripped)) {
+    if (!path) continue;
+    const err = validateAssetPath(path);
+    if (err) return errorResponse(400, `entry "${path}": ${err}`);
+    pending.push({
+      path,
+      bytes,
+      contentType: contentTypeForPath(path),
+    });
+  }
+
+  let nextManifest: StaticSiteFileBlob;
+  try {
+    // Try to preserve the existing entry, else `applyReplaceAll`
+    // picks the shallowest .html.
+    nextManifest = applyReplaceAll(pending, manifest.entry);
+  } catch (e) {
+    if (e instanceof StaticSiteError) return errorResponse(e.status, e.message);
+    throw e;
+  }
+
+  // Drop the old R2 objects, then write the new ones. Failures during
+  // the bulk delete are best-effort (the next site delete cleans up).
+  await deleteAllStaticSiteAssets(c.env, id);
+  await writePendingAssets(c.env, id, pending);
+  const committed = await commitManifest(c.env, row, nextManifest);
+  return siteResponse(c.env, owner, row, nextManifest, committed);
+});
+
+// DELETE /api/files/:id/assets/:path{.+} — remove one asset by
+// relpath. Hono's bare `*` wildcard isn't exposed as a route
+// parameter, so we use a regex-named param `:path{.+}` which
+// matches "any non-empty remainder including slashes."
+r.delete("/:id/assets/:path{.+}", async (c) => {
+  const owner = c.get("session").userId;
+  const id = c.req.param("id");
+  // `c.req.param('path')` returns the captured tail with slashes
+  // preserved. Already URL-decoded by Hono.
+  const path = c.req.param("path") ?? "";
+  const pathErr = validateAssetPath(path);
+  if (pathErr) return errorResponse(400, pathErr);
+
+  const loaded = await loadStaticSite(c.env, owner, id);
+  if (loaded instanceof Response) return loaded;
+  const { row, manifest } = loaded;
+
+  const mismatch = checkIfMatch(c.req.raw, row);
+  if (mismatch) return mismatch;
+
+  let nextManifest: StaticSiteFileBlob;
+  try {
+    nextManifest = applyDelete(manifest, path);
+  } catch (e) {
+    if (e instanceof StaticSiteError) return errorResponse(e.status, e.message);
+    throw e;
+  }
+
+  await deletePendingPaths(c.env, id, [path]);
+  const committed = await commitManifest(c.env, row, nextManifest);
+  return siteResponse(c.env, owner, row, nextManifest, committed);
+});
+
+// POST /api/files/:id/render-session — mint a short-lived signed URL
+// prefix the owner's editor (or any preview iframe) can use to serve
+// the site through `/sites/:id/:sig/<relpath>`.
+//
+// No payload is required — the owner is taken from the session and
+// the signature is bound to (file id, owner id). The returned prefix
+// has a trailing slash so the caller can concat `manifest.entry`.
+r.post("/:id/render-session", async (c) => {
+  const owner = c.get("session").userId;
+  const id = c.req.param("id");
+  const row = await filesRepo.findById(c.env, owner, id);
+  if (!row) return errorResponse(404, "file not found");
+  if (row.kind !== "static-site") return errorResponse(400, "file is not a static-site");
+  const signed = await signRender(c.env.SESSION_SECRET, ownerRenderPayload(row.id, row.owner));
+  return jsonResponse({
+    prefix: `/sites/${row.id}/${signed.sig}/`,
+    expiresAt: signed.expiresAt,
+  });
+});
+
+// PUT /api/files/:id/entry — set the entry asset.
+r.put("/:id/entry", async (c) => {
+  const owner = c.get("session").userId;
+  const id = c.req.param("id");
+  const body = await parseJson<{ path?: unknown }>(c);
+  if (body instanceof Response) return body;
+  if (typeof body.path !== "string") return errorResponse(400, "path required");
+
+  const loaded = await loadStaticSite(c.env, owner, id);
+  if (loaded instanceof Response) return loaded;
+  const { row, manifest } = loaded;
+
+  const mismatch = checkIfMatch(c.req.raw, row);
+  if (mismatch) return mismatch;
+
+  let nextManifest: StaticSiteFileBlob;
+  try {
+    nextManifest = applySetEntry(manifest, body.path);
+  } catch (e) {
+    if (e instanceof StaticSiteError) return errorResponse(e.status, e.message);
+    throw e;
+  }
+
+  const committed = await commitManifest(c.env, row, nextManifest);
+  return siteResponse(c.env, owner, row, nextManifest, committed);
+});
+
+/**
+ * If every key in `entries` shares the same top-level directory,
+ * strip it. Otherwise return `entries` unchanged. Helps users who
+ * `zip -r mybundle.zip mybundle/` end up with a flat layout.
+ */
+function stripCommonPrefix(entries: Record<string, Uint8Array>): Record<string, Uint8Array> {
+  const keys = Object.keys(entries).filter((k) => k.length > 0);
+  if (keys.length === 0) return entries;
+  const first = keys[0];
+  const slash = first.indexOf("/");
+  if (slash < 0) return entries;
+  const prefix = first.slice(0, slash + 1);
+  for (const k of keys) {
+    if (!k.startsWith(prefix)) return entries;
+  }
+  const out: Record<string, Uint8Array> = {};
+  for (const [k, v] of Object.entries(entries)) {
+    out[k.slice(prefix.length)] = v;
+  }
+  return out;
+}
 
 // ─── Internal helpers exposed to other route modules ────────────────
 //

--- a/worker/routes/public-share.ts
+++ b/worker/routes/public-share.ts
@@ -12,6 +12,7 @@ import { Hono } from "hono";
 import * as filesRepo from "../db/repos/files";
 import * as foldersRepo from "../db/repos/folders";
 import * as tagsRepo from "../db/repos/tags";
+import { shareRenderPayload, signRender } from "../lib/crypto";
 import {
   errorResponse,
   jsonResponse,
@@ -68,6 +69,53 @@ r.get(
     const file = await filesRepo.findByIdAnyOwner(c.env, tk.target_id);
     if (!file?.has_thumb) return errorResponse(404, "no thumbnail");
     return await serveR2WithCache(c.env, c.executionCtx ?? null, c.req.raw, r2ThumbKey(file.id));
+  },
+);
+
+// POST /api/share/:token/render-session — mint a short-lived signed
+// URL prefix for a static-site file behind a file share. The visitor
+// is redirected to `prefix + manifest.entry`. Revoking the share
+// immediately kills outstanding sessions (the render route re-checks
+// `findActive` on every request).
+r.post(
+  "/:token/render-session",
+  requireShareToken({ target: "file", targetMismatchMessage: "not a file share" }),
+  async (c) => {
+    const tk = c.get("share");
+    const file = await filesRepo.findByIdAnyOwner(c.env, tk.target_id);
+    if (!file) return errorResponse(404, "file not found");
+    if (file.kind !== "static-site") return errorResponse(400, "file is not a static-site");
+    const signed = await signRender(c.env.SESSION_SECRET, shareRenderPayload(tk.token, file.id));
+    return jsonResponse({
+      prefix: `/shared/${tk.token}/${signed.sig}/`,
+      expiresAt: signed.expiresAt,
+    });
+  },
+);
+
+// POST /api/share/:token/files/:fileId/render-session — folder-share
+// analogue. The folder share must cover the requested file; the file
+// itself must be a static-site. URL shape is
+// `/shared/:token/files/:fileId/:sig/<relpath>` to disambiguate from
+// the file-share URL shape (which has no `files` segment).
+r.post(
+  "/:token/files/:fileId/render-session",
+  requireShareToken({ target: "folder", targetMismatchMessage: "not a folder share" }),
+  async (c) => {
+    const tk = c.get("share");
+    const fileId = c.req.param("fileId");
+    if (!fileId) return errorResponse(404, "file not in shared folder");
+    if (!(await foldersRepo.fileInSubtree(c.env, tk.owner, fileId, tk.target_id))) {
+      return errorResponse(404, "file not in shared folder");
+    }
+    const file = await filesRepo.findByIdAnyOwner(c.env, fileId);
+    if (!file) return errorResponse(404, "file not found");
+    if (file.kind !== "static-site") return errorResponse(400, "file is not a static-site");
+    const signed = await signRender(c.env.SESSION_SECRET, shareRenderPayload(tk.token, file.id));
+    return jsonResponse({
+      prefix: `/shared/${tk.token}/files/${file.id}/${signed.sig}/`,
+      expiresAt: signed.expiresAt,
+    });
   },
 );
 

--- a/worker/routes/render.ts
+++ b/worker/routes/render.ts
@@ -1,0 +1,259 @@
+// Static-site asset render endpoints.
+//
+// Two routers are exported, mounted at top-level paths in
+// `worker/index.ts`:
+//
+//   * `ownerSites`  → `/sites/:id/:sig/<relpath>`
+//                     Owner-minted signed URLs. Sig payload is
+//                     `ownerRenderPayload(id, owner)` so it's
+//                     bound to (this file, this owner).
+//
+//   * `sharedSites` → `/shared/:token/:sig/<relpath>`
+//                     Share-token-minted signed URLs. Sig payload is
+//                     `shareRenderPayload(token, id)`. Each request
+//                     also re-checks `sharesRepo.findActive` so
+//                     revoking a share kills outstanding URLs in
+//                     flight even though the sig hasn't expired yet.
+//
+// Both flavors live OUTSIDE `/api/*`. The `/api/*` namespace is
+// reserved for session-authed JSON endpoints; these routes serve
+// uploader HTML/CSS/JS bytes and are authorized strictly by the HMAC
+// signature in the URL path (the signing secret never leaves the
+// worker). Keeping them on their own top-level paths also keeps the
+// URL you see in "Open in new tab" looking like a regular site URL,
+// not an API call.
+//
+// ─── Cookies vs. signatures ──────────────────────────────────────
+//
+// The two routers differ in how they authenticate:
+//
+//   * `ownerSites` REQUIRES a session cookie. `requireSession` runs
+//     before every handler and `row.owner === session.userId` is
+//     re-checked per request. The HMAC signature stays as a
+//     TTL-bound defense in depth that binds the URL to (file, owner)
+//     and prevents id-substitution attacks. Sub-resource requests
+//     (`<script>`, `<img>`, `<link>`) inside the rendered HTML carry
+//     the cookie because they are same-origin GETs and the cookie is
+//     `SameSite=Lax`.
+//
+//   * `sharedSites` is cookie-less by design — a share-token URL is
+//     the credential. Each request re-resolves the share row via
+//     `sharesRepo.findActive`, so revoke/expire take effect
+//     immediately even though the sig TTL hasn't elapsed.
+//
+// ─── Access-control invariants ────────────────────────────────────
+//
+//   1. `ownerRenderPayload` and `shareRenderPayload` produce
+//      structurally different strings ("owner|…" vs "share|…"). An
+//      owner-minted signature literally cannot HMAC-verify against the
+//      share verifier and vice versa.
+//   2. Each route handler hard-codes the matching payload builder.
+//      Param names differ (`:id` vs `:token`) so there's no shape
+//      under which the wrong path could feed the wrong verifier.
+//   3. The owner route additionally requires a session cookie and
+//      that the authenticated user owns the file. The share routes
+//      additionally re-query the share row on every request and
+//      reject if the share is gone, expired, or no longer covers the
+//      requested file.
+//   4. Asset paths are resolved by exact Map lookup against the
+//      manifest, so `..`-style traversal in the relpath segment
+//      cannot escape the bundle even if it somehow reached the
+//      resolver (it doesn't; HMAC verification gates it first).
+//
+// Any future change to these routes must preserve all four
+// invariants — especially #1 (payload separation) and #2 (the
+// verifier-vs-handler binding).
+
+import { Hono } from "hono";
+import * as filesRepo from "../db/repos/files";
+import * as foldersRepo from "../db/repos/folders";
+import * as sharesRepo from "../db/repos/shares";
+import { ownerRenderPayload, shareRenderPayload, verifyRender } from "../lib/crypto";
+import { errorResponse } from "../lib/responses";
+import { requireSession } from "../middleware/auth";
+import type { AppEnv } from "../middleware/types";
+import { r2StaticSiteAssetKey, readManifest } from "../services/static-site";
+import type { Env, FileRow, StaticSiteFileBlob } from "../types";
+
+// ─── Owner-minted (mounted at `/sites`) ───────────────────────────
+// Hono's bare `*` wildcard isn't exposed as a named param, so we use
+// `:path{.*}` (regex-named, matches empty so the root request
+// resolves to `manifest.entry`).
+const ownerSites = new Hono<AppEnv>();
+ownerSites.use("*", requireSession);
+
+ownerSites.get("/:id/:sig/:path{.*}", async (c) => {
+  const session = c.get("session");
+  const id = c.req.param("id");
+  const sig = c.req.param("sig");
+  const relpath = c.req.param("path") ?? "";
+  if (!id || !sig) return errorResponse(404, "not found");
+
+  const row = await filesRepo.findByIdAnyOwner(c.env, id);
+  if (!row || row.kind !== "static-site") return errorResponse(404, "not found");
+
+  // Ownership check: the signed URL binds to (file, owner) but the
+  // authoritative gate is the session cookie. An attacker who obtains
+  // a sig URL out-of-band (URL leak, browser history sync, etc.)
+  // still can't replay it without being signed in as the owner.
+  if (row.owner !== session.userId) return errorResponse(403, "not authorized");
+
+  // Verifier is locked to `ownerRenderPayload`. A share-minted sig
+  // produces a payload starting with "share|" and therefore cannot
+  // satisfy this check — see "Access-control invariants" above.
+  const ok = await verifyRender(c.env.SESSION_SECRET, sig, ownerRenderPayload(row.id, row.owner));
+  if (!ok) return errorResponse(403, "expired or invalid render session");
+
+  return await serveAsset(c.env, row, relpath);
+});
+
+// ─── Share-token-minted (mounted at `/shared`) ────────────────────
+//
+// Two URL shapes:
+//
+//   * File share:   `/shared/:token/:sig/<relpath>`
+//   * Folder share: `/shared/:token/files/:fileId/:sig/<relpath>`
+//
+// The folder-share shape carries the file id explicitly because a
+// single folder share can host many static-site files; the sig still
+// binds to (token, fileId) via `shareRenderPayload`. Route order
+// matters: the folder-share route below is declared first so Hono's
+// literal `files` segment wins over the `:sig` capture in the
+// file-share route.
+const sharedSites = new Hono<AppEnv>();
+
+sharedSites.get("/:token/files/:fileId/:sig/:path{.*}", async (c) => {
+  const token = c.req.param("token");
+  const fileId = c.req.param("fileId");
+  const sig = c.req.param("sig");
+  const relpath = c.req.param("path") ?? "";
+  if (!token || !fileId || !sig) return errorResponse(404, "not found");
+
+  const share = await sharesRepo.findActive(c.env, token);
+  if (!share || share.target_type !== "folder") {
+    return errorResponse(403, "share is no longer active");
+  }
+  if (!(await foldersRepo.fileInSubtree(c.env, share.owner, fileId, share.target_id))) {
+    return errorResponse(403, "file not in shared folder");
+  }
+
+  const row = await filesRepo.findByIdAnyOwner(c.env, fileId);
+  if (!row || row.kind !== "static-site") return errorResponse(404, "not found");
+
+  // Same verifier as the file-share path: `shareRenderPayload(token,
+  // fileId)`. The fileId is part of the URL, so a folder-share sig
+  // minted for file A cannot be replayed against file B.
+  const ok = await verifyRender(c.env.SESSION_SECRET, sig, shareRenderPayload(token, fileId));
+  if (!ok) return errorResponse(403, "expired or invalid render session");
+
+  return await serveAsset(c.env, row, relpath);
+});
+
+sharedSites.get("/:token/:sig/:path{.*}", async (c) => {
+  const token = c.req.param("token");
+  const sig = c.req.param("sig");
+  const relpath = c.req.param("path") ?? "";
+  if (!token || !sig) return errorResponse(404, "not found");
+
+  // Re-check share is still active. Owner-minted signatures don't
+  // need this because if the file is deleted, the manifest 404s
+  // below; but a share can be revoked while the file is still alive
+  // and we want revocation to take effect immediately rather than
+  // waiting for the 30-minute signature TTL.
+  const share = await sharesRepo.findActive(c.env, token);
+  if (!share || share.target_type !== "file") {
+    return errorResponse(403, "share is no longer active");
+  }
+
+  const row = await filesRepo.findByIdAnyOwner(c.env, share.target_id);
+  if (!row || row.kind !== "static-site") return errorResponse(404, "not found");
+
+  // Verifier is locked to `shareRenderPayload`. An owner-minted sig
+  // produces a payload starting with "owner|" and therefore cannot
+  // satisfy this check — see "Access-control invariants" above.
+  const ok = await verifyRender(c.env.SESSION_SECRET, sig, shareRenderPayload(token, row.id));
+  if (!ok) return errorResponse(403, "expired or invalid render session");
+
+  return await serveAsset(c.env, row, relpath);
+});
+
+// ─── Asset resolver + serve ───────────────────────────────────────
+async function serveAsset(env: Env, row: FileRow, relpath: string): Promise<Response> {
+  const manifest = await readManifest(env, row.id);
+  if (!manifest) return errorResponse(500, "manifest missing");
+
+  const resolved = resolveAssetPath(manifest, relpath);
+  if (!resolved) return errorResponse(404, "asset not found");
+
+  const obj = await env.R2.get(r2StaticSiteAssetKey(row.id, resolved.path));
+  if (!obj) return errorResponse(404, "asset missing in R2");
+
+  // CSP rationale: this content is the uploader's own HTML/CSS/JS.
+  // We deliberately allow loose `script-src` / `style-src` (incl.
+  // `'unsafe-inline'`/`'unsafe-eval'`) so the uploader's site behaves
+  // the way it was authored. The real security boundary is the
+  // dedicated tab — `frame-ancestors 'self'` plus `X-Frame-Options:
+  // SAMEORIGIN` ensure only Inkwell-origin pages can iframe these
+  // assets, which prevents an attacker from embedding a victim's
+  // signed URL inside a phishing page.
+  //
+  // `Referrer-Policy: no-referrer` keeps the signed URL out of
+  // outbound link Referer headers (so a click from inside the user's
+  // site doesn't leak the HMAC to third parties).
+  const headers = new Headers();
+  headers.set("content-type", resolved.contentType);
+  headers.set("cache-control", "private, max-age=300");
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("x-frame-options", "SAMEORIGIN");
+  headers.set("referrer-policy", "no-referrer");
+  headers.set(
+    "content-security-policy",
+    "default-src 'self' data: blob: https:; " +
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https:; " +
+      "style-src 'self' 'unsafe-inline' data: blob: https:; " +
+      "img-src 'self' data: blob: https:; " +
+      "font-src 'self' data: blob: https:; " +
+      "frame-ancestors 'self'",
+  );
+  if (obj.httpEtag) headers.set("etag", obj.httpEtag);
+
+  return new Response(obj.body, { headers });
+}
+
+/** Resolve a request relpath to an actual manifest entry.
+ *
+ *  * "" or trailing-slash → look for `<base>index.html` in the
+ *    manifest. For the empty root case, fall back to `manifest.entry`.
+ *  * exact path hit → return that asset.
+ *  * otherwise → null (404).
+ *
+ *  Path traversal (`..`) cannot escape the bundle: we look up assets
+ *  by exact Map key, never by file-system path. The HMAC gate before
+ *  this function is the real defense in depth.
+ */
+function resolveAssetPath(
+  manifest: StaticSiteFileBlob,
+  relpath: string,
+): { path: string; contentType: string } | null {
+  // Normalize: collapse leading slashes; we don't accept ".." but the
+  // signed prefix isolation makes that moot.
+  let p = relpath.replace(/^\/+/, "");
+
+  const byPath = new Map(manifest.assets.map((a) => [a.path, a]));
+
+  // Root request → manifest.entry.
+  if (p === "" || p === "/") {
+    const hit = byPath.get(manifest.entry);
+    return hit ? { path: hit.path, contentType: hit.contentType } : null;
+  }
+
+  // Directory-style request → look for index.html under it.
+  if (p.endsWith("/")) {
+    p = `${p}index.html`;
+  }
+
+  const hit = byPath.get(p);
+  return hit ? { path: hit.path, contentType: hit.contentType } : null;
+}
+
+export { ownerSites, sharedSites };

--- a/worker/routes/shares.ts
+++ b/worker/routes/shares.ts
@@ -51,6 +51,18 @@ sharesRoot.patch("/:token", async (c) => {
   // extend the expiry on a link they're still using.
   if (row.revoked_at) return errorResponse(410, "share is revoked");
 
+  // Static-site file shares are view-only by design — no share-side
+  // asset mutators exist. Reject permission=write up front so we
+  // never persist a row whose permission silently doesn't match the
+  // runtime behavior. Folder shares are unaffected: a folder-share
+  // write permission applies to the non-static-site files inside.
+  if (body.permission === "write" && row.target_type === "file") {
+    const file = await filesRepo.findByIdAnyOwner(c.env, row.target_id);
+    if (file && file.kind === "static-site") {
+      return errorResponse(400, "static-site shares cannot grant write access");
+    }
+  }
+
   // Resolve the next state. Each field is independent: undefined
   // leaves it alone, a value replaces it, `null` is the explicit clear
   // for nullable fields.
@@ -148,6 +160,10 @@ fileSharesNested.post("/", async (c) => {
   const row = await filesRepo.findById(c.env, owner, fileId);
   if (!row) return errorResponse(404, "file not found");
   const body = await parseJsonOrEmpty<CreateShareBody>(c);
+  // Static-site shares are view-only — see PATCH handler above.
+  if (row.kind === "static-site" && body.permission === "write") {
+    return errorResponse(400, "static-site shares cannot grant write access");
+  }
   const created = await createShareRow(c.env, owner, "file", fileId, body);
   return jsonResponse(rowToSharePublic(created));
 });

--- a/worker/services/delete-cascade.ts
+++ b/worker/services/delete-cascade.ts
@@ -10,6 +10,7 @@ import * as filesRepo from "../db/repos/files";
 import { r2FileKey, r2ThumbKey } from "../lib/responses";
 import { now } from "../lib/util";
 import type { Env, FolderRow } from "../types";
+import { deleteAllStaticSiteAssets } from "./static-site";
 
 // Delete one file: cascade shares + taggings, then drop the row, then
 // best-effort R2 cleanup. Used by both the owner endpoint and the
@@ -23,7 +24,15 @@ export async function deleteFileCascade(env: Env, owner: string, id: string): Pr
       .where(and(eq(t.taggings.target_type, "file"), eq(t.taggings.target_id, id))),
     db.delete(t.files).where(and(eq(t.files.id, id), eq(t.files.owner, owner))),
   ]);
-  await Promise.allSettled([env.R2.delete(r2FileKey(id)), env.R2.delete(r2ThumbKey(id))]);
+  // Always drop the static-site asset prefix unconditionally: the
+  // helper paginates an R2 list under `static-sites/<id>/` and no-ops
+  // when there are no objects, so we don't need to branch on `kind`
+  // here (kind isn't loaded at this layer anyway).
+  await Promise.allSettled([
+    env.R2.delete(r2FileKey(id)),
+    env.R2.delete(r2ThumbKey(id)),
+    deleteAllStaticSiteAssets(env, id),
+  ]);
 }
 
 // Delete one folder. Children (direct files + subfolders) move up one
@@ -91,6 +100,8 @@ export async function deleteUserCascade(env: Env, userId: string): Promise<void>
     for (const id of fileIds) {
       deletes.push(env.R2.delete(r2FileKey(id)));
       deletes.push(env.R2.delete(r2ThumbKey(id)));
+      // No-op for kinds that don't have a static-site prefix.
+      deletes.push(deleteAllStaticSiteAssets(env, id));
     }
     await Promise.allSettled(deletes);
   }

--- a/worker/services/file-blob.ts
+++ b/worker/services/file-blob.ts
@@ -20,14 +20,27 @@ import type {
   FileMeta,
   FileRow,
   NotesFileBlob,
+  StaticSiteFileBlob,
 } from "../types";
 import { rowToMeta } from "../types";
+import { emptyManifest, isStaticSiteBlob, validateManifest, writeSeedSite } from "./static-site";
 
 export const MAX_FILE_BYTES = 25 * 1024 * 1024;
 export const MAX_THUMB_BYTES = 1 * 1024 * 1024;
 
 // ─── Blob construction ──────────────────────────────────────────────
-export function seedBlobForKind(kind: FileKind, name: string): FileBlob {
+//
+// Two-phase seeding:
+//   1. `seedManifestForKind(kind, name)` returns the JSON manifest
+//      that will be stored at `r2FileKey(id)`. Pure — no R2 writes.
+//   2. `writeSeedSite(env, id, name)` (static-site only) writes the
+//      seed `index.html` to R2 under `static-sites/<id>/` and then
+//      writes the canonical manifest. The other kinds need no extra
+//      R2 writes — the manifest IS the seed blob.
+//
+// `seedBlobForKind` is preserved as a back-compat alias; new code
+// should prefer `seedManifestForKind` for clarity.
+export function seedManifestForKind(kind: FileKind, name: string): FileBlob {
   switch (kind) {
     case "drawio":
       return { kind: "drawio", xml: emptyDrawioXml(name) };
@@ -35,10 +48,16 @@ export function seedBlobForKind(kind: FileKind, name: string): FileBlob {
       return { elements: [], appState: { name }, files: {} };
     case "notes":
       return { kind: "notes", blocks: [{ type: "paragraph", content: [] }] };
+    case "static-site":
+      // The canonical seed manifest (with one asset entry) is built
+      // by `writeSeedSite`; this sentinel keeps the function pure.
+      return emptyManifest();
     default:
       return assertNever(kind);
   }
 }
+
+export const seedBlobForKind = seedManifestForKind;
 
 function emptyDrawioXml(name: string): string {
   const safeName = escapeXml(name || "Page-1");
@@ -80,6 +99,13 @@ export function validateBlobForKind(kind: FileKind, parsed: FileBlob): string | 
     case "notes":
       if (!isNotesBlob(parsed)) return "notes blob must include kind=notes and blocks array";
       return null;
+    case "static-site":
+      // Direct manifest PUTs are not supported — `putFileBlob` short-
+      // circuits before reaching here. This branch is a defensive
+      // fallback for any future code path that calls the validator
+      // directly (e.g. round-trip symmetry tests).
+      if (!isStaticSiteBlob(parsed)) return "static-site blob shape invalid";
+      return validateManifest(parsed as StaticSiteFileBlob);
     default:
       return assertNever(kind);
   }
@@ -104,6 +130,14 @@ export async function writeR2Blob(
 // place. `row` must already be loaded; the caller is responsible for
 // authorization (owner check, share-token resolution, etc.).
 export async function putFileBlob(env: Env, row: FileRow, req: Request): Promise<Response> {
+  // Static-site manifests are server-managed — owners mutate the site
+  // through the dedicated /api/files/:id/assets* endpoints, which keep
+  // the R2 objects and the manifest in lockstep. Allowing a raw
+  // manifest PUT here would let a client desync the two.
+  if (row.kind === "static-site") {
+    return errorResponse(400, "static-site files are managed via /api/files/:id/assets endpoints");
+  }
+
   // Optimistic concurrency: if the client supplies If-Match and it
   // doesn't match the current version, refuse and return the current
   // metadata so the client can decide what to do.
@@ -172,9 +206,22 @@ export async function createFileInFolder(
   const id = newId();
   const ts = now();
   const safe = (name || "Untitled").slice(0, 200);
-  const seed = seedBlobForKind(kind, safe);
-  const seedBytes = new TextEncoder().encode(JSON.stringify(seed));
-  await writeR2Blob(env, id, seedBytes);
+
+  // Static-site uses a two-phase seed: write the seed asset to R2
+  // first, then `writeSeedSite` builds the canonical manifest and
+  // writes it to the standard blob key. The other kinds bundle the
+  // seed and the manifest into one JSON blob.
+  let totalBytes: number;
+  if (kind === "static-site") {
+    const seeded = await writeSeedSite(env, id, safe);
+    totalBytes = seeded.bytes;
+  } else {
+    const seed = seedManifestForKind(kind, safe);
+    const seedBytes = new TextEncoder().encode(JSON.stringify(seed));
+    await writeR2Blob(env, id, seedBytes);
+    totalBytes = seedBytes.byteLength;
+  }
+
   await filesRepo.insert(env, {
     id,
     owner,
@@ -182,7 +229,7 @@ export async function createFileInFolder(
     name: safe,
     kind,
     version: 1,
-    size_bytes: seedBytes.byteLength,
+    size_bytes: totalBytes,
     has_thumb: false,
     thumb_updated_at: 0,
     created_at: ts,
@@ -195,7 +242,7 @@ export async function createFileInFolder(
     kind,
     tags: [],
     version: 1,
-    sizeBytes: seedBytes.byteLength,
+    sizeBytes: totalBytes,
     hasThumb: false,
     thumbUpdatedAt: 0,
     activeShareCount: 0,

--- a/worker/services/static-site.ts
+++ b/worker/services/static-site.ts
@@ -1,0 +1,523 @@
+// Static-site service.
+//
+// Owns everything that's specific to the `static-site` file kind:
+//
+//   * Manifest shape construction, validation, and read/write to R2.
+//   * Asset path validation (relpath rules).
+//   * Content-type resolution from extension.
+//   * R2 layout for per-asset objects under `static-sites/<id>/<relpath>`.
+//   * Bulk delete of an entire site's assets (used by file + user cascade).
+//   * Mutators that keep the R2 truth and the manifest in lockstep —
+//     the manifest is rewritten last so a crash leaves orphan R2
+//     objects (harmless) but never a manifest pointing at missing data.
+//
+// The manifest is stored at the canonical `r2FileKey(id)` (i.e.
+// `scenes/<id>.json`) so the existing `streamFileResponse` and
+// `GET /api/files/:id` plumbing serves it without any kind branching.
+// Direct PUTs of the manifest are rejected in `putFileBlob` — owners
+// mutate via the asset endpoints, which call into here.
+
+import * as filesRepo from "../db/repos/files";
+import { r2FileKey } from "../lib/responses";
+import { now } from "../lib/util";
+import type { Env, FileRow, StaticSiteAsset, StaticSiteFileBlob } from "../types";
+
+// ─── Caps ───────────────────────────────────────────────────────────
+/** Single-asset upload cap. Matches existing `MAX_FILE_BYTES`. */
+export const MAX_SITE_ASSET_BYTES = 25 * 1024 * 1024;
+/** Whole-site total cap (sum across all assets). */
+export const MAX_SITE_TOTAL_BYTES = 100 * 1024 * 1024;
+/** Maximum number of assets per site. */
+export const MAX_SITE_ASSET_COUNT = 500;
+/** Per-segment and full-path string caps. */
+export const MAX_ASSET_PATH_BYTES = 1000;
+
+// ─── Path validation ────────────────────────────────────────────────
+//
+// Asset paths are forward-slash, lowercased only in lookups (preserved
+// in storage). Rules:
+//   * no leading `/`
+//   * no empty segments (rules out `foo//bar` and trailing `/`)
+//   * no `.` or `..` segments
+//   * no NUL or backslash anywhere
+//   * length cap to avoid pathological R2 keys
+//
+// Returns null on success, an error message otherwise.
+export function validateAssetPath(p: string): string | null {
+  if (typeof p !== "string") return "path must be a string";
+  if (!p) return "path required";
+  if (p.length > MAX_ASSET_PATH_BYTES) return `path too long (max ${MAX_ASSET_PATH_BYTES} chars)`;
+  if (p.startsWith("/")) return "path must not start with /";
+  if (p.includes("\\")) return "path must not contain backslash";
+  if (p.includes("\0")) return "path must not contain NUL";
+  const parts = p.split("/");
+  for (const seg of parts) {
+    if (!seg) return "path must not contain empty segments";
+    if (seg === "." || seg === "..") return "path must not contain . or .. segments";
+    if (seg.length > 255) return "path segment too long";
+  }
+  return null;
+}
+
+/** Reject layouts where one path is a strict directory prefix of
+ *  another (e.g. `assets` as a file vs. `assets/foo.css` as a dir).
+ *  Operates on the *post-mutation* manifest. */
+export function findPathPrefixCollision(paths: string[]): string | null {
+  const set = new Set(paths);
+  for (const p of paths) {
+    const segs = p.split("/");
+    for (let i = 1; i < segs.length; i++) {
+      const ancestor = segs.slice(0, i).join("/");
+      if (set.has(ancestor)) {
+        return `path "${p}" collides with file "${ancestor}"`;
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Content-type map ───────────────────────────────────────────────
+const CONTENT_TYPE_MAP: Record<string, string> = {
+  html: "text/html; charset=utf-8",
+  htm: "text/html; charset=utf-8",
+  css: "text/css; charset=utf-8",
+  js: "text/javascript; charset=utf-8",
+  mjs: "text/javascript; charset=utf-8",
+  json: "application/json; charset=utf-8",
+  map: "application/json; charset=utf-8",
+  txt: "text/plain; charset=utf-8",
+  md: "text/plain; charset=utf-8",
+  xml: "application/xml; charset=utf-8",
+  svg: "image/svg+xml; charset=utf-8",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  ico: "image/x-icon",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  ttf: "font/ttf",
+  otf: "font/otf",
+  eot: "application/vnd.ms-fontobject",
+  wasm: "application/wasm",
+  pdf: "application/pdf",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mp3: "audio/mpeg",
+  ogg: "audio/ogg",
+};
+
+export function contentTypeForPath(p: string): string {
+  const dot = p.lastIndexOf(".");
+  if (dot < 0) return "application/octet-stream";
+  const ext = p.slice(dot + 1).toLowerCase();
+  return CONTENT_TYPE_MAP[ext] ?? "application/octet-stream";
+}
+
+// ─── Manifest IO ────────────────────────────────────────────────────
+export function emptyManifest(entry = "index.html"): StaticSiteFileBlob {
+  return { kind: "static-site", entry, assets: [] };
+}
+
+export function isStaticSiteBlob(blob: unknown): blob is StaticSiteFileBlob {
+  if (!blob || typeof blob !== "object") return false;
+  const o = blob as { kind?: unknown; entry?: unknown; assets?: unknown };
+  if (o.kind !== "static-site") return false;
+  if (typeof o.entry !== "string" || !o.entry) return false;
+  if (!Array.isArray(o.assets)) return false;
+  for (const a of o.assets) {
+    if (!a || typeof a !== "object") return false;
+    const r = a as Record<string, unknown>;
+    if (typeof r.path !== "string") return false;
+    if (typeof r.size !== "number") return false;
+    if (typeof r.contentType !== "string") return false;
+    if (typeof r.updatedAt !== "number") return false;
+  }
+  return true;
+}
+
+/** Validate a parsed manifest. Returns null on success or an error
+ *  message. Also enforces the path-prefix-collision invariant and that
+ *  `entry` exists in `assets`. */
+export function validateManifest(m: StaticSiteFileBlob): string | null {
+  if (!isStaticSiteBlob(m)) return "invalid static-site manifest shape";
+  const entryErr = validateAssetPath(m.entry);
+  if (entryErr) return `entry: ${entryErr}`;
+  if (m.assets.length === 0) return "static-site must have at least one asset";
+  if (m.assets.length > MAX_SITE_ASSET_COUNT) {
+    return `too many assets (max ${MAX_SITE_ASSET_COUNT})`;
+  }
+  const paths: string[] = [];
+  let total = 0;
+  const seen = new Set<string>();
+  for (const a of m.assets) {
+    const pErr = validateAssetPath(a.path);
+    if (pErr) return `asset "${a.path}": ${pErr}`;
+    if (seen.has(a.path)) return `duplicate asset path "${a.path}"`;
+    seen.add(a.path);
+    if (a.size < 0 || a.size > MAX_SITE_ASSET_BYTES) {
+      return `asset "${a.path}" size out of range`;
+    }
+    total += a.size;
+    paths.push(a.path);
+  }
+  if (total > MAX_SITE_TOTAL_BYTES) {
+    return `site total ${total} exceeds cap ${MAX_SITE_TOTAL_BYTES}`;
+  }
+  const collision = findPathPrefixCollision(paths);
+  if (collision) return collision;
+  if (!seen.has(m.entry)) return `entry "${m.entry}" not present in assets`;
+  return null;
+}
+
+export async function readManifest(env: Env, id: string): Promise<StaticSiteFileBlob | null> {
+  const obj = await env.R2.get(r2FileKey(id));
+  if (!obj) return null;
+  try {
+    const parsed = JSON.parse(await obj.text()) as unknown;
+    return isStaticSiteBlob(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeManifest(
+  env: Env,
+  id: string,
+  manifest: StaticSiteFileBlob,
+): Promise<void> {
+  // Always sort assets alphabetically before writing so diffs and
+  // listings are deterministic.
+  const sorted: StaticSiteFileBlob = {
+    ...manifest,
+    assets: [...manifest.assets].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0)),
+  };
+  await env.R2.put(r2FileKey(id), JSON.stringify(sorted), {
+    httpMetadata: { contentType: "application/json" },
+  });
+}
+
+// ─── R2 layout for assets ───────────────────────────────────────────
+export function r2StaticSiteAssetKey(id: string, relpath: string): string {
+  return `static-sites/${id}/${relpath}`;
+}
+
+export function r2StaticSitePrefix(id: string): string {
+  return `static-sites/${id}/`;
+}
+
+/** Paginated delete of every R2 object under a site's prefix.
+ *  Best-effort: failures are swallowed (D1 row is the source of truth
+ *  for what *should* exist). */
+export async function deleteAllStaticSiteAssets(env: Env, id: string): Promise<void> {
+  const prefix = r2StaticSitePrefix(id);
+  let cursor: string | undefined;
+  do {
+    const list = await env.R2.list({ prefix, cursor, limit: 1000 });
+    const keys = list.objects.map((o) => o.key);
+    if (keys.length > 0) {
+      // R2.delete accepts an array on supported runtimes; fall back to
+      // a Promise.allSettled fan-out to avoid runtime surprises.
+      try {
+        await env.R2.delete(keys);
+      } catch {
+        await Promise.allSettled(keys.map((k) => env.R2.delete(k)));
+      }
+    }
+    cursor = list.truncated ? list.cursor : undefined;
+  } while (cursor);
+}
+
+// ─── Manifest mutations ─────────────────────────────────────────────
+//
+// All mutators take the *current* manifest, return the next one, and
+// throw a typed error on validation failure. Callers are responsible
+// for writing R2 objects (or removing them) before persisting the
+// next manifest via `commitManifest`.
+
+export class StaticSiteError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/** One asset's bytes + resolved metadata, ready to be written. */
+export interface PendingAsset {
+  path: string;
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+/** Apply a batch of (path → bytes) upserts to a manifest in-place
+ *  (immutably) and return the new manifest. Existing entries with the
+ *  same path are replaced; the asset's `updatedAt` is refreshed.
+ *
+ *  Throws `StaticSiteError` if any path is invalid, if the resulting
+ *  asset count exceeds `MAX_SITE_ASSET_COUNT`, if the resulting total
+ *  size exceeds `MAX_SITE_TOTAL_BYTES`, or if any individual asset
+ *  exceeds `MAX_SITE_ASSET_BYTES`. */
+export function applyUpserts(
+  manifest: StaticSiteFileBlob,
+  pending: PendingAsset[],
+): StaticSiteFileBlob {
+  const ts = now();
+  const next = new Map<string, StaticSiteAsset>();
+  for (const a of manifest.assets) next.set(a.path, a);
+  for (const p of pending) {
+    const err = validateAssetPath(p.path);
+    if (err) throw new StaticSiteError(400, `asset "${p.path}": ${err}`);
+    if (p.bytes.byteLength > MAX_SITE_ASSET_BYTES) {
+      throw new StaticSiteError(413, `asset "${p.path}" exceeds ${MAX_SITE_ASSET_BYTES} bytes`);
+    }
+    next.set(p.path, {
+      path: p.path,
+      size: p.bytes.byteLength,
+      contentType: p.contentType,
+      updatedAt: ts,
+    });
+  }
+  if (next.size > MAX_SITE_ASSET_COUNT) {
+    throw new StaticSiteError(413, `too many assets (max ${MAX_SITE_ASSET_COUNT})`);
+  }
+  let total = 0;
+  for (const a of next.values()) total += a.size;
+  if (total > MAX_SITE_TOTAL_BYTES) {
+    throw new StaticSiteError(413, `site total ${total} exceeds cap ${MAX_SITE_TOTAL_BYTES}`);
+  }
+  const paths = Array.from(next.keys());
+  const collision = findPathPrefixCollision(paths);
+  if (collision) throw new StaticSiteError(409, collision);
+  return {
+    kind: "static-site",
+    entry: manifest.entry,
+    assets: Array.from(next.values()).sort((a, b) =>
+      a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+    ),
+  };
+}
+
+/** Remove one asset by path. Refuses to remove the entry (callers must
+ *  change the entry first). */
+export function applyDelete(manifest: StaticSiteFileBlob, path: string): StaticSiteFileBlob {
+  if (!manifest.assets.some((a) => a.path === path)) {
+    throw new StaticSiteError(404, `asset "${path}" not found`);
+  }
+  if (manifest.entry === path) {
+    throw new StaticSiteError(409, `cannot delete entry asset "${path}" — change entry first`);
+  }
+  if (manifest.assets.length <= 1) {
+    // Defense in depth: the entry-check above already catches this,
+    // since a single-asset site has that asset as the entry.
+    throw new StaticSiteError(409, "static-site must have at least one asset");
+  }
+  return {
+    ...manifest,
+    assets: manifest.assets.filter((a) => a.path !== path),
+  };
+}
+
+/** Replace the entry. The new path must exist in the manifest. */
+export function applySetEntry(manifest: StaticSiteFileBlob, path: string): StaticSiteFileBlob {
+  const err = validateAssetPath(path);
+  if (err) throw new StaticSiteError(400, `entry: ${err}`);
+  if (!manifest.assets.some((a) => a.path === path)) {
+    throw new StaticSiteError(404, `entry "${path}" not present in assets`);
+  }
+  return { ...manifest, entry: path };
+}
+
+/** Replace the entire asset set (used by ZIP-replace upload). */
+export function applyReplaceAll(
+  pending: PendingAsset[],
+  preferredEntry: string,
+): StaticSiteFileBlob {
+  if (pending.length === 0) {
+    throw new StaticSiteError(400, "static-site must have at least one asset");
+  }
+  const ts = now();
+  const map = new Map<string, StaticSiteAsset>();
+  let total = 0;
+  for (const p of pending) {
+    const err = validateAssetPath(p.path);
+    if (err) throw new StaticSiteError(400, `asset "${p.path}": ${err}`);
+    if (p.bytes.byteLength > MAX_SITE_ASSET_BYTES) {
+      throw new StaticSiteError(413, `asset "${p.path}" exceeds ${MAX_SITE_ASSET_BYTES} bytes`);
+    }
+    if (map.has(p.path)) throw new StaticSiteError(409, `duplicate asset "${p.path}"`);
+    total += p.bytes.byteLength;
+    map.set(p.path, {
+      path: p.path,
+      size: p.bytes.byteLength,
+      contentType: p.contentType,
+      updatedAt: ts,
+    });
+  }
+  if (map.size > MAX_SITE_ASSET_COUNT) {
+    throw new StaticSiteError(413, `too many assets (max ${MAX_SITE_ASSET_COUNT})`);
+  }
+  if (total > MAX_SITE_TOTAL_BYTES) {
+    throw new StaticSiteError(413, `site total ${total} exceeds cap ${MAX_SITE_TOTAL_BYTES}`);
+  }
+  const collision = findPathPrefixCollision(Array.from(map.keys()));
+  if (collision) throw new StaticSiteError(409, collision);
+
+  // Resolve entry: prefer the caller's choice if it exists, else the
+  // shallowest .html file, else 400.
+  let entry = preferredEntry;
+  if (!map.has(entry)) {
+    const htmls = Array.from(map.keys())
+      .filter((p) => /\.html?$/i.test(p))
+      .sort((a, b) => {
+        const da = a.split("/").length;
+        const db = b.split("/").length;
+        if (da !== db) return da - db;
+        return a < b ? -1 : a > b ? 1 : 0;
+      });
+    if (htmls.length === 0) {
+      throw new StaticSiteError(400, "no .html file found in upload — cannot pick entry");
+    }
+    entry = htmls[0];
+  }
+
+  return {
+    kind: "static-site",
+    entry,
+    assets: Array.from(map.values()).sort((a, b) =>
+      a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+    ),
+  };
+}
+
+// ─── R2 + manifest co-write ─────────────────────────────────────────
+//
+// Two phases:
+//   1. Validate via the in-memory mutator (throws on failure).
+//   2. Write R2 objects, then write manifest, then bump the D1 row.
+//
+// The R2 writes happen *before* the manifest write so a partial crash
+// leaves orphan R2 objects (cleaned on next `deleteAllStaticSiteAssets`)
+// but never a manifest pointing at missing bytes.
+
+export async function writePendingAssets(
+  env: Env,
+  id: string,
+  pending: PendingAsset[],
+): Promise<void> {
+  // Run uploads in modest parallel batches to avoid spraying every
+  // request at R2 at once for large uploads.
+  const BATCH = 16;
+  for (let i = 0; i < pending.length; i += BATCH) {
+    const slice = pending.slice(i, i + BATCH);
+    await Promise.all(
+      slice.map((p) =>
+        env.R2.put(r2StaticSiteAssetKey(id, p.path), p.bytes, {
+          httpMetadata: { contentType: p.contentType },
+        }),
+      ),
+    );
+  }
+}
+
+export async function deletePendingPaths(env: Env, id: string, paths: string[]): Promise<void> {
+  if (paths.length === 0) return;
+  try {
+    await env.R2.delete(paths.map((p) => r2StaticSiteAssetKey(id, p)));
+  } catch {
+    await Promise.allSettled(paths.map((p) => env.R2.delete(r2StaticSiteAssetKey(id, p))));
+  }
+}
+
+/** Commit a manifest + bump the file row's `version`, `size_bytes`,
+ *  and `updated_at`. Returns the new version. */
+export async function commitManifest(
+  env: Env,
+  row: FileRow,
+  next: StaticSiteFileBlob,
+): Promise<{ version: number; sizeBytes: number; updatedAt: number }> {
+  await writeManifest(env, row.id, next);
+  const totalBytes = next.assets.reduce((a, b) => a + b.size, 0);
+  const updatedAt = now();
+  const version = row.version + 1;
+  await filesRepo.updateMeta(env, row.owner, row.id, {
+    version,
+    size_bytes: totalBytes,
+    updated_at: updatedAt,
+  });
+  return { version, sizeBytes: totalBytes, updatedAt };
+}
+
+// ─── Seed initial asset for a brand-new static-site ────────────────
+//
+// Called by `createFileInFolder` and the owner-side create endpoint
+// right after the file row is inserted. Writes a minimal placeholder
+// `index.html` to R2 and returns the seed manifest so the caller can
+// store it as the canonical blob.
+
+const SEED_INDEX_HTML = (name: string) => `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escapeHtml(name)}</title>
+<style>
+  body { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.6; color: #1f2937; }
+  h1 { font-weight: 700; letter-spacing: -0.01em; }
+  p { color: #4b5563; }
+  code { background: #f3f4f6; padding: 0.1rem 0.3rem; border-radius: 4px; font-size: 0.95em; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(name)}</h1>
+<p>This is an empty static site. Upload files (or a <code>.zip</code> archive) to replace this page.</p>
+</body>
+</html>
+`;
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Build the seed asset bytes (no R2 writes). The caller chains this
+ *  with `writeSeedSite` after the file row exists. */
+export function buildSeedAsset(name: string): PendingAsset {
+  const html = SEED_INDEX_HTML(name);
+  return {
+    path: "index.html",
+    bytes: new TextEncoder().encode(html),
+    contentType: contentTypeForPath("index.html"),
+  };
+}
+
+/** Write the seed `index.html` to R2 and write the seed manifest.
+ *  Returns the seed manifest and the seed byte count. */
+export async function writeSeedSite(
+  env: Env,
+  id: string,
+  name: string,
+): Promise<{ manifest: StaticSiteFileBlob; bytes: number }> {
+  const seed = buildSeedAsset(name);
+  await writePendingAssets(env, id, [seed]);
+  const manifest: StaticSiteFileBlob = {
+    kind: "static-site",
+    entry: "index.html",
+    assets: [
+      {
+        path: seed.path,
+        size: seed.bytes.byteLength,
+        contentType: seed.contentType,
+        updatedAt: now(),
+      },
+    ],
+  };
+  await writeManifest(env, id, manifest);
+  return { manifest, bytes: seed.bytes.byteLength };
+}

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -121,7 +121,7 @@ export type FolderRow = InferSelectModel<typeof t.folders>;
 // Compact preview info for a single file inside a folder. Used by
 // `FolderCard` to render thumbnails between the folds. Carries only
 // what the card needs — not the full FileMeta.
-export type FileKind = "excalidraw" | "drawio" | "notes";
+export type FileKind = "excalidraw" | "drawio" | "notes" | "static-site";
 
 /** Coerce arbitrary user input to a valid FileKind. Anything that
  *  isn't an explicit known variant collapses to "excalidraw" — the
@@ -130,6 +130,7 @@ export type FileKind = "excalidraw" | "drawio" | "notes";
 export function normalizeFileKind(input: unknown): FileKind {
   if (input === "drawio") return "drawio";
   if (input === "notes") return "notes";
+  if (input === "static-site") return "static-site";
   return "excalidraw";
 }
 
@@ -269,7 +270,34 @@ export interface NotesFileBlob {
   blocks: unknown[];
 }
 
-export type FileBlob = ExcalidrawFileBlob | DrawioFileBlob | NotesFileBlob;
+/** One asset inside a static-site bundle. Paths are forward-slash,
+ *  no leading slash, no `..`, no empty segments. `contentType` is
+ *  resolved from the extension at upload time so the render route
+ *  can serve assets without re-sniffing. */
+export interface StaticSiteAsset {
+  path: string;
+  size: number;
+  contentType: string;
+  /** unix-ms of the most recent upload of this asset. */
+  updatedAt: number;
+}
+
+/** Manifest for a `kind === "static-site"` file. Stored as the
+ *  canonical R2 JSON blob (same key path as the other kinds) so
+ *  `streamFileResponse` and the existing reader plumbing work
+ *  unchanged. Mutations go through dedicated asset endpoints; direct
+ *  PUTs of this manifest are rejected to keep R2 and the manifest
+ *  consistent. */
+export interface StaticSiteFileBlob {
+  kind: "static-site";
+  /** Asset path served for the root request (`GET /sites/.../` or `GET /shared/.../`).
+   *   Must exist in `assets`. */
+  entry: string;
+  /** Sorted alphabetically by path. */
+  assets: StaticSiteAsset[];
+}
+
+export type FileBlob = ExcalidrawFileBlob | DrawioFileBlob | NotesFileBlob | StaticSiteFileBlob;
 
 // ─── Shares (polymorphic) ────────────────────────────────────────────
 export type SharePermission = "read" | "write";


### PR DESCRIPTION
## Summary

Introduces a fourth file kind — **`static-site`** — for publishing
multi-asset HTML/CSS/JS bundles alongside the existing Excalidraw,
draw.io, and Notes kinds.

## Worker

- **`worker/services/static-site.ts`** (new) owns the manifest shape,
  R2 layout (`static-sites/<id>/<relpath>`), per-asset and whole-site
  size caps, content-type resolution, and bulk delete used by both the
  file and user cascades. The canonical JSON manifest is rewritten
  *last* so a crash leaves harmless orphan R2 objects but never a
  manifest pointing at missing data. Direct PUTs of the manifest blob
  are rejected — owners mutate via the asset endpoints.
- **`worker/routes/render.ts`** (new) exposes two top-level routers:
  - `/sites/:id/:sig/<relpath>` — owner-minted signed URLs; the sig
    payload is bound to (file id, owner id) and requires a session
    cookie.
  - `/shared/:token/:sig/<relpath>` — share-token-minted signed URLs;
    each request re-checks `sharesRepo.findActive` so revoking a share
    kills outstanding URLs in flight even before the sig expires.
  Both live **outside `/api/*`** so uploaded JS cannot read session
  cookies or call owner-authed endpoints.
- Supporting changes in `files.ts`, `public-share.ts`, `shares.ts`,
  `services/delete-cascade.ts`, `services/file-blob.ts`,
  `lib/crypto.ts`, `lib/responses.ts`, `types.ts`, and `db/schema.ts`
  add the upload/list/delete endpoints, HMAC payload helpers, and type
  plumbing.

## Client

- **`StaticSiteEditor`** + `static-site/{FileRow, FilesList, SiteCard,
  UploadPanel, fileKindChip}` for managing uploaded assets and
  previewing the site.
- New route **`/f/:id/site`** → `StaticSitePreviewRedirect` mints a
  fresh signed `/sites/:id/:sig/...` URL on every visit and
  `location.replace`s into it, giving owners a stable bookmarkable
  preview URL.
- `NewFileDialog`, `ShareDialog` + share forms, `file-kind-icons`, and
  `brand-logos` updated to surface the new kind. API client
  (`lib/api/client.ts`, `query-keys.ts`) gains the static-site
  endpoints.

## Misc

- `fflate` added for client-side zip handling.
- `README` documents the new kind and signed-URL design.

## Verification

- `pnpm check:ci` — passes (3 pre-existing `noImportantStyles`
  warnings in `src/index.css`, unrelated to this change).
- `pnpm typecheck` — clean (`tsconfig.app.json` + `tsconfig.worker.json`).